### PR TITLE
Add per-crate `CHANGELOG.md` files

### DIFF
--- a/ui-events-winit/CHANGELOG.md
+++ b/ui-events-winit/CHANGELOG.md
@@ -8,15 +8,20 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published UI Events release is [0.X.Y](#0XY-2025-01-01) which was released on 2025-01-01.
-You can find its changes [documented below](#0XY-2025-01-01).
+The latest published UI Events Winit release is [0.1.0](#010-2025-05-08) which was released on 2025-05-08.
+You can find its changes [documented below](#010-2025-05-08).
 
 ## [Unreleased]
+
+This release has an [MSRV][] of 1.73.
+
+## [0.1.0][] - 2025-05-08
 
 This release has an [MSRV][] of 1.73.
 
 This is the initial release.
 
 [Unreleased]: https://github.com/endoli/ui-events/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0
 
 [MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/ui-events/CHANGELOG.md
+++ b/ui-events/CHANGELOG.md
@@ -1,0 +1,27 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+The latest published UI Events release is [0.1.0](#010-2025-05-08) which was released on 2025-05-08.
+You can find its changes [documented below](#010-2025-05-08).
+
+## [Unreleased]
+
+This release has an [MSRV][] of 1.73.
+
+## [0.1.0][] - 2025-05-08
+
+This release has an [MSRV][] of 1.73.
+
+This is the initial release.
+
+[Unreleased]: https://github.com/endoli/ui-events/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/linebender/color/releases/tag/v0.1.0
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/ui-theme/CHANGELOG.md
+++ b/ui-theme/CHANGELOG.md
@@ -1,0 +1,22 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+The latest published UI Theme release is [0.X.Y](#0XY-2025-01-01) which was released on 2025-01-01.
+You can find its changes [documented below](#0XY-2025-01-01).
+
+## [Unreleased]
+
+This release has an [MSRV][] of 1.73.
+
+This is the initial release.
+
+[Unreleased]: https://github.com/endoli/ui-events/compare/v0.1.0...HEAD
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv


### PR DESCRIPTION
These crates will not all have identical release cadences, so we should document their changelogs separately.