### PR TITLE
Set default members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["ui-events", "ui-events-winit", "ui-theme", "examples/simple"]
+default-members = ["ui-events", "ui-events-winit", "ui-theme"]
 
 [workspace.package]
 # UI Events version, also used by other packages which want to mimic UI Events' version.


### PR DESCRIPTION
Means that `cargo build`, `cargo check`, etc will build these crates by default (without specifying `--workspace`)