### PR TITLE
Pattern match `PointerEvent::Scroll` consistently

### DIFF
--- a/ui-events-winit/src/lib.rs
+++ b/ui-events-winit/src/lib.rs
@@ -349,7 +349,7 @@ impl TapCounter {
                     .retain(|TapState { pointer_id, .. }| *pointer_id != p.pointer_id);
                 PointerEvent::Cancel(p)
             }
-            e @ (PointerEvent::Enter(..) | PointerEvent::Scroll { .. }) => e,
+            e @ (PointerEvent::Enter(..) | PointerEvent::Scroll(..)) => e,
         }
     }
 


### PR DESCRIPTION
This is now a separate struct, so match it like we do the other structs.