### PR TITLE
ui-events-winit: Don't map `Leave` to `Cancel`

### DIFF
--- a/ui-events-winit/src/lib.rs
+++ b/ui-events-winit/src/lib.rs
@@ -347,7 +347,7 @@ impl TapCounter {
             PointerEvent::Leave(p) => {
                 self.taps
                     .retain(|TapState { pointer_id, .. }| *pointer_id != p.pointer_id);
-                PointerEvent::Cancel(p)
+                PointerEvent::Leave(p)
             }
             e @ (PointerEvent::Enter(..) | PointerEvent::Scroll { .. }) => e,
         }


### PR DESCRIPTION
The tap events enhancement code was changing a `Leave` event into a `Cancel` rather than returning the same type of event.

This was introduced in b8e0cc41.