### PR TITLE
`ui-events-winit`: Use `web-time` on wasm32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1131,6 +1131,7 @@ name = "ui-events-winit"
 version = "0.1.0"
 dependencies = [
  "ui-events",
+ "web-time",
  "winit",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,4 @@ clippy.wildcard_dependencies = "warn"
 [workspace.dependencies]
 dpi = { version = "0.1.2", default-features = false }
 ui-events = { version = "0.1.0", path = "ui-events", default-features = false }
+web-time = "1.1.0"

--- a/ui-events-winit/Cargo.toml
+++ b/ui-events-winit/Cargo.toml
@@ -23,5 +23,8 @@ std = []
 ui-events = { workspace = true, features = ["std"] }
 winit = "0.30.10"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time.workspace = true
+
 [lints]
 workspace = true

--- a/ui-events-winit/src/lib.rs
+++ b/ui-events-winit/src/lib.rs
@@ -26,8 +26,14 @@ pub mod pointer;
 extern crate alloc;
 use alloc::{vec, vec::Vec};
 
+#[cfg(not(target_arch = "wasm32"))]
 extern crate std;
-use std::time::Instant;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+pub use web_time::Instant;
 
 use ui_events::{
     keyboard::KeyboardEvent,


### PR DESCRIPTION
Fixes #69