### PR TITLE
Align MSRV docs of ui-theme with workspace Rust version

### DIFF
--- a/ui-theme/CHANGELOG.md
+++ b/ui-theme/CHANGELOG.md
@@ -13,7 +13,7 @@ You can find its changes [documented below](#0XY-2025-01-01).
 
 ## [Unreleased]
 
-This release has an [MSRV][] of 1.73.
+This release has an [MSRV][] of 1.85.
 
 This is the initial release.
 

--- a/ui-theme/README.md
+++ b/ui-theme/README.md
@@ -32,8 +32,8 @@ UI Theme is a Rust crate which ...
 
 ## Minimum supported Rust Version (MSRV)
 
-This version of UI Theme has been verified to compile with **Rust 1.73** and later.
-The `no_std` build of this library needs **Rust 1.81** and later.
+This version of UI Theme has been verified to compile with **Rust 1.85** and later.
+The `no_std` build of this library needs **Rust 1.85** and later.
 
 Future versions of UI Theme might increase the Rust version requirement.
 It will not be treated as a breaking change and as such can even happen with small patch releases.


### PR DESCRIPTION
Updates `ui-theme`'s `README` and changelog to state Rust 1.85 as the MSRV, matching the workspace rust version to avoid confusion for users.