### PR TITLE
text: add IME composition, edit commands, and web/winit adapters

### DIFF
--- a/ui-events-appkit/README.md
+++ b/ui-events-appkit/README.md
@@ -38,6 +38,8 @@ Currently supported:
 - Pointer (mouse/pen) down/up/move/enter/leave/scroll
 - Trackpad gestures: magnify (pinch) and rotate
 - Keyboard down/up
+- Text-input mapping helpers for committed text, composition updates, and
+  UTF-16 replacement ranges
 - `AppKitInputResponder`, a reusable `NSResponder` for pointer, scroll,
   gesture, tablet, and keyboard input
 
@@ -104,12 +106,22 @@ edit-command protocols.
   modifier while the other side remains held may still report the key as
   down until this adapter grows device-dependent left/right modifier masks.
 
+## Text Notes
+
+- [`text`] contains value-based helpers for translating AppKit UTF-16
+  location/length pairs and text callbacks into [`TextInputEvent`] values.
+- The reusable `AppKitInputResponder` still does not implement `NSTextInput`
+  protocols. Hosts that implement those protocols can use the text helpers
+  from their own responder or view.
+
 ## High-Level Helpers
 
 - `AppKitInputResponder`
 - `pointer_event_from_nsevent`
 - `pointer_event_from_nsevent_at_position`
 - `keyboard_event_from_nsevent`
+- `text::text_insert_event`
+- `text::composition_update_event_with_utf16_ranges`
 
 If you prefer, low-level mappers in [`mapping`] let you build events from
 raw values (e.g. coordinates, button number, modifier booleans) without
@@ -118,6 +130,7 @@ pulling in AppKit types in your own code.
 [`PointerType::Pen`]: ui_events::pointer::PointerType::Pen
 [`ScrollDelta::LineDelta`]: ui_events::ScrollDelta::LineDelta
 [`ScrollDelta::PixelDelta`]: ui_events::ScrollDelta::PixelDelta
+[`TextInputEvent`]: ui_events::text::TextInputEvent
 [`ui-events`]: https://docs.rs/ui-events/
 
 <!-- cargo-rdme end -->

--- a/ui-events-appkit/src/lib.rs
+++ b/ui-events-appkit/src/lib.rs
@@ -16,6 +16,8 @@
 //! - Pointer (mouse/pen) down/up/move/enter/leave/scroll
 //! - Trackpad gestures: magnify (pinch) and rotate
 //! - Keyboard down/up
+//! - Text-input mapping helpers for committed text, composition updates, and
+//!   UTF-16 replacement ranges
 //! - `AppKitInputResponder`, a reusable `NSResponder` for pointer, scroll,
 //!   gesture, tablet, and keyboard input
 //!
@@ -82,12 +84,22 @@
 //!   modifier while the other side remains held may still report the key as
 //!   down until this adapter grows device-dependent left/right modifier masks.
 //!
+//! ## Text Notes
+//!
+//! - [`text`] contains value-based helpers for translating AppKit UTF-16
+//!   location/length pairs and text callbacks into [`TextInputEvent`] values.
+//! - The reusable `AppKitInputResponder` still does not implement `NSTextInput`
+//!   protocols. Hosts that implement those protocols can use the text helpers
+//!   from their own responder or view.
+//!
 //! ## High-Level Helpers
 //!
 //! - `AppKitInputResponder`
 //! - `pointer_event_from_nsevent`
 //! - `pointer_event_from_nsevent_at_position`
 //! - `keyboard_event_from_nsevent`
+//! - `text::text_insert_event`
+//! - `text::composition_update_event_with_utf16_ranges`
 //!
 //! If you prefer, low-level mappers in [`mapping`] let you build events from
 //! raw values (e.g. coordinates, button number, modifier booleans) without
@@ -96,6 +108,7 @@
 //! [`PointerType::Pen`]: ui_events::pointer::PointerType::Pen
 //! [`ScrollDelta::LineDelta`]: ui_events::ScrollDelta::LineDelta
 //! [`ScrollDelta::PixelDelta`]: ui_events::ScrollDelta::PixelDelta
+//! [`TextInputEvent`]: ui_events::text::TextInputEvent
 //! [`ui-events`]: https://docs.rs/ui-events/
 
 #![allow(unsafe_code, reason = "We access platform libraries using ffi.")]
@@ -104,6 +117,7 @@
 extern crate alloc;
 
 pub mod mapping;
+pub use ui_events_apple_common::text;
 
 #[cfg(target_os = "macos")]
 pub mod appkit;

--- a/ui-events-apple-common/README.md
+++ b/ui-events-apple-common/README.md
@@ -45,6 +45,8 @@ decide which platform callbacks should become which high-level events.
 - Modifier helpers build [`Modifiers`] from platform modifier bits.
 - State helpers build [`PointerState`] and [`ScrollDelta`] from finite raw
   values already extracted by an adapter crate.
+- Text helpers build [`TextInputEvent`] values from UTF-16 ranges used by
+  Apple text-input APIs.
 
 These helpers are intentionally small and value-based. AppKit and UIKit
 crates still own all Objective-C selector access and platform-specific event
@@ -56,6 +58,7 @@ routing.
 [`PointerId::PRIMARY`]: ui_events::pointer::PointerId::PRIMARY
 [`PointerState`]: ui_events::pointer::PointerState
 [`ScrollDelta`]: ui_events::ScrollDelta
+[`TextInputEvent`]: ui_events::text::TextInputEvent
 [`ui-events`]: https://docs.rs/ui-events/
 
 <!-- cargo-rdme end -->

--- a/ui-events-apple-common/src/lib.rs
+++ b/ui-events-apple-common/src/lib.rs
@@ -23,6 +23,8 @@
 //! - Modifier helpers build [`Modifiers`] from platform modifier bits.
 //! - State helpers build [`PointerState`] and [`ScrollDelta`] from finite raw
 //!   values already extracted by an adapter crate.
+//! - Text helpers build [`TextInputEvent`] values from UTF-16 ranges used by
+//!   Apple text-input APIs.
 //!
 //! These helpers are intentionally small and value-based. AppKit and UIKit
 //! crates still own all Objective-C selector access and platform-specific event
@@ -34,14 +36,18 @@
 //! [`PointerId::PRIMARY`]: ui_events::pointer::PointerId::PRIMARY
 //! [`PointerState`]: ui_events::pointer::PointerState
 //! [`ScrollDelta`]: ui_events::ScrollDelta
+//! [`TextInputEvent`]: ui_events::text::TextInputEvent
 //! [`ui-events`]: https://docs.rs/ui-events/
 
 #![no_std]
+
+extern crate alloc;
 
 mod buttons;
 mod identity;
 mod modifiers;
 mod state;
+pub mod text;
 
 pub use buttons::{buttons_from_bitmask, try_from_button_index};
 pub use identity::{

--- a/ui-events-apple-common/src/text.rs
+++ b/ui-events-apple-common/src/text.rs
@@ -1,0 +1,195 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Shared text-input mapping helpers for Apple adapters.
+//!
+//! AppKit and UIKit both expose document ranges as UTF-16 location/length
+//! pairs. These helpers convert those raw values into the transport-agnostic
+//! [`ui_events::text`] event model without depending on AppKit, UIKit, or
+//! Objective-C types.
+
+use alloc::string::String;
+
+use ui_events::text::{CompositionState, TextInputEvent, TextInsertEvent, TextTargetRange};
+
+/// Convert an Apple UTF-16 `location`/`length` pair into a target range.
+///
+/// Returns `None` when `location + length` overflows `u32`.
+pub const fn utf16_range_from_location_length(
+    location: u32,
+    length: u32,
+) -> Option<TextTargetRange> {
+    match location.checked_add(length) {
+        Some(end) => Some(TextTargetRange::utf16_code_units(location, end)),
+        None => None,
+    }
+}
+
+/// Build a committed text insertion event.
+pub fn text_insert_event(text: impl Into<String>) -> TextInputEvent {
+    TextInputEvent::Insert(TextInsertEvent::new(text))
+}
+
+/// Build a committed text insertion event with an Apple UTF-16 replacement range.
+///
+/// This is suitable for AppKit/UIKit callbacks that provide a document range
+/// alongside committed text.
+pub fn text_insert_event_with_utf16_replacement(
+    text: impl Into<String>,
+    location: u32,
+    length: u32,
+) -> Option<TextInputEvent> {
+    let replacement_range = utf16_range_from_location_length(location, length)?;
+    Some(TextInputEvent::Insert(
+        TextInsertEvent::new(text).with_replacement_range(replacement_range),
+    ))
+}
+
+/// Build a composition update from composing text and an optional UTF-16
+/// selection within that composing text.
+///
+/// Apple APIs commonly report selected ranges in UTF-16 code units. The core
+/// [`CompositionState`] stores selection inside the composing string as UTF-8
+/// byte offsets, so this helper validates and converts the selection against
+/// `text`.
+///
+/// `selection_location` and `selection_length` must either both be provided or
+/// both be absent. A half-specified selection returns `None`.
+pub fn composition_update_event_with_utf16_selection(
+    text: impl Into<String>,
+    selection_location: Option<u32>,
+    selection_length: Option<u32>,
+) -> Option<TextInputEvent> {
+    let text = text.into();
+    let mut state = CompositionState::new(text);
+    match (selection_location, selection_length) {
+        (Some(location), Some(length)) => {
+            let range = utf16_range_from_location_length(location, length)?;
+            let selection = range.to_utf8_range_in(&state.text)?;
+            state = state.try_with_selection(selection)?;
+        }
+        (None, None) => {}
+        _ => return None,
+    }
+    Some(TextInputEvent::CompositionUpdate(state))
+}
+
+/// Build a composition update with a UTF-16 document replacement range.
+///
+/// `selection_location`/`selection_length`, when provided, are interpreted
+/// within the composing text. `replacement_location`/`replacement_length` are
+/// interpreted in the host document.
+pub fn composition_update_event_with_utf16_ranges(
+    text: impl Into<String>,
+    selection_location: Option<u32>,
+    selection_length: Option<u32>,
+    replacement_location: Option<u32>,
+    replacement_length: Option<u32>,
+) -> Option<TextInputEvent> {
+    let mut state = match composition_update_event_with_utf16_selection(
+        text,
+        selection_location,
+        selection_length,
+    )? {
+        TextInputEvent::CompositionUpdate(state) => state,
+        _ => unreachable!("helper only returns composition updates"),
+    };
+    match (replacement_location, replacement_length) {
+        (Some(location), Some(length)) => {
+            state =
+                state.with_replacement_range(utf16_range_from_location_length(location, length)?);
+        }
+        (None, None) => {}
+        _ => return None,
+    }
+    Some(TextInputEvent::CompositionUpdate(state))
+}
+
+/// Build a composition-end event.
+pub const fn composition_end_event() -> TextInputEvent {
+    TextInputEvent::CompositionEnd
+}
+
+/// Build a backward-delete text event.
+pub const fn delete_backward_event() -> TextInputEvent {
+    TextInputEvent::DeleteBackward
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ui_events::text::{TextRange, TextRangeEncoding};
+
+    #[test]
+    fn utf16_ranges_use_location_plus_length() {
+        let range = utf16_range_from_location_length(2, 3).expect("valid range");
+        assert_eq!(range.range, TextRange::new(2, 5));
+        assert_eq!(range.encoding, TextRangeEncoding::Utf16CodeUnits);
+        assert_eq!(utf16_range_from_location_length(u32::MAX, 1), None);
+    }
+
+    #[test]
+    fn insert_event_preserves_utf16_replacement_range() {
+        assert_eq!(
+            text_insert_event_with_utf16_replacement("x", 1, 2),
+            Some(TextInputEvent::replace(
+                "x",
+                TextTargetRange::utf16_code_units(1, 3)
+            ))
+        );
+    }
+
+    #[test]
+    fn composition_selection_converts_to_utf8_offsets() {
+        assert_eq!(
+            composition_update_event_with_utf16_selection("a🙂b", Some(1), Some(2)),
+            Some(TextInputEvent::CompositionUpdate(
+                CompositionState::new("a🙂b").with_selection(TextRange::new(1, 5))
+            ))
+        );
+    }
+
+    #[test]
+    fn composition_selection_rejects_half_specified_selection() {
+        assert_eq!(
+            composition_update_event_with_utf16_selection("abc", Some(1), None),
+            None
+        );
+        assert_eq!(
+            composition_update_event_with_utf16_selection("abc", None, Some(1)),
+            None
+        );
+    }
+
+    #[test]
+    fn composition_update_preserves_document_replacement_range() {
+        assert_eq!(
+            composition_update_event_with_utf16_ranges("ni", Some(0), Some(2), Some(4), Some(3)),
+            Some(TextInputEvent::CompositionUpdate(
+                CompositionState::new("ni")
+                    .with_selection(TextRange::new(0, 2))
+                    .with_replacement_range(TextTargetRange::utf16_code_units(4, 7))
+            ))
+        );
+    }
+
+    #[test]
+    fn composition_update_rejects_half_specified_replacement_range() {
+        assert_eq!(
+            composition_update_event_with_utf16_ranges("ni", Some(0), Some(2), Some(4), None),
+            None
+        );
+        assert_eq!(
+            composition_update_event_with_utf16_ranges("ni", Some(0), Some(2), None, Some(3)),
+            None
+        );
+    }
+
+    #[test]
+    fn composition_selection_rejects_invalid_utf16_boundaries() {
+        assert_eq!(
+            composition_update_event_with_utf16_selection("🙂", Some(1), Some(1)),
+            None
+        );
+    }
+}

--- a/ui-events-uikit/README.md
+++ b/ui-events-uikit/README.md
@@ -40,6 +40,8 @@ Currently supported:
 - Pencil hover enter/move/leave when UIKit reports region phases
 - tvOS remote presses → keyboard
 - Hardware keyboard via `UIPress` + `UIKey`
+- Text-input mapping helpers for committed text, composition updates, and
+  UTF-16 replacement ranges
 - `UIKitInputResponder`, a reusable `UIResponder` for touch, remote, and
   keyboard input
 
@@ -82,11 +84,21 @@ Currently supported:
   previous scale. Rotation gesture recognizers follow the same pattern with
   cumulative counterclockwise `rotation` values.
 
+## Text Notes
+
+- [`text`] contains value-based helpers for translating UIKit UTF-16
+  location/length pairs and text callbacks into [`TextInputEvent`] values.
+- The reusable `UIKitInputResponder` still does not implement `UIKeyInput`
+  or full text-input protocols. Hosts that implement those protocols can use
+  the text helpers from their own responder or view.
+
 ## High-Level Helpers
 
 - `UIKitInputResponder`
 - `keyboard_event_from_uipress`
 - `keyboard_event_from_uikey`
+- `text::text_insert_event`
+- `text::composition_update_event_with_utf16_ranges`
 - `pointer_event_from_touch_and_event`
 - `pointer_event_from_touch` (uncommon convenience helper)
 - `pointer_gesture_from_uipinch` (feature: `gestures`)
@@ -99,6 +111,7 @@ raw values (e.g. coordinates, button number, modifier booleans) without
 pulling in UIKit types in your own code.
 
 [`ui-events`]: https://docs.rs/ui-events/
+[`TextInputEvent`]: ui_events::text::TextInputEvent
 
 <!-- cargo-rdme end -->
 

--- a/ui-events-uikit/src/lib.rs
+++ b/ui-events-uikit/src/lib.rs
@@ -18,6 +18,8 @@
 //! - Pencil hover enter/move/leave when UIKit reports region phases
 //! - tvOS remote presses → keyboard
 //! - Hardware keyboard via `UIPress` + `UIKey`
+//! - Text-input mapping helpers for committed text, composition updates, and
+//!   UTF-16 replacement ranges
 //! - `UIKitInputResponder`, a reusable `UIResponder` for touch, remote, and
 //!   keyboard input
 //!
@@ -60,11 +62,21 @@
 //!   previous scale. Rotation gesture recognizers follow the same pattern with
 //!   cumulative counterclockwise `rotation` values.
 //!
+//! ## Text Notes
+//!
+//! - [`text`] contains value-based helpers for translating UIKit UTF-16
+//!   location/length pairs and text callbacks into [`TextInputEvent`] values.
+//! - The reusable `UIKitInputResponder` still does not implement `UIKeyInput`
+//!   or full text-input protocols. Hosts that implement those protocols can use
+//!   the text helpers from their own responder or view.
+//!
 //! ## High-Level Helpers
 //!
 //! - `UIKitInputResponder`
 //! - `keyboard_event_from_uipress`
 //! - `keyboard_event_from_uikey`
+//! - `text::text_insert_event`
+//! - `text::composition_update_event_with_utf16_ranges`
 //! - `pointer_event_from_touch_and_event`
 //! - `pointer_event_from_touch` (uncommon convenience helper)
 //! - `pointer_gesture_from_uipinch` (feature: `gestures`)
@@ -77,6 +89,7 @@
 //! pulling in UIKit types in your own code.
 //!
 //! [`ui-events`]: https://docs.rs/ui-events/
+//! [`TextInputEvent`]: ui_events::text::TextInputEvent
 
 #![allow(unsafe_code, reason = "We access platform libraries using ffi.")]
 #![no_std]
@@ -84,6 +97,7 @@
 extern crate alloc;
 
 pub mod mapping;
+pub use ui_events_apple_common::text;
 
 #[cfg(any(target_os = "ios", target_os = "tvos"))]
 pub mod input_responder;

--- a/ui-events-web/Cargo.toml
+++ b/ui-events-web/Cargo.toml
@@ -24,6 +24,9 @@ ui-events = { workspace = true, default-features = false }
 dpi.workspace = true
 js-sys = { version = "0.3.82", default-features = false }
 web-sys = { version = "0.3.82", default-features = false, features = [
+    "CompositionEvent",
+    "Event",
+    "InputEvent",
     "KeyboardEvent",
     "MouseEvent",
     "Touch",
@@ -39,8 +42,10 @@ workspace = true
 
 [dev-dependencies]
 web-sys = { version = "0.3.82", features = [
+    "CompositionEvent",
     "DomRect",
     "Element",
+    "InputEvent",
     "KeyboardEvent",
     "PointerEvent",
     "Window",

--- a/ui-events-web/README.md
+++ b/ui-events-web/README.md
@@ -29,12 +29,17 @@ Wheel, and Keyboard — into the [`ui-events`] model.
 
 It provides lightweight helpers to convert browser events into portable
 `ui-events` types you can feed into your input handling. It supports
-Pointer Events (mouse, touch, pen) and keyboard.
+Pointer Events (mouse, touch, pen), keyboard, and text/composition input.
 
 ## Keyboard
 
 - [`keyboard::from_web_keyboard_event`]
 - Optional helpers: [`keyboard::from_web_keydown_event`], [`keyboard::from_web_keyup_event`]
+
+## Text / Composition
+
+- [`text::text_event_from_dom_event`]
+- Typed helpers: [`text::from_web_input_event`], [`text::from_web_composition_event`]
 
 ## Pointer (Pointer Events)
 
@@ -80,6 +85,11 @@ Pointer Events (mouse, touch, pen) and keyboard.
   - Stylus rotation/twist (Pointer Events `twist`) is not currently exposed by `ui-events`,
     so it is not mapped.
 - Keyboard: unknown `key`/`code` map to `Unidentified`; `is_composing` reflects the DOM flag.
+- Text:
+  - `CompositionEvent` maps to composition update/end.
+  - `InputEvent` maps committed insertions and simple backward/forward deletion intents.
+  - DOM target ranges are node-relative and are not currently converted into `ui-events`
+    replacement ranges.
 
 ## Example
 

--- a/ui-events-web/src/lib.rs
+++ b/ui-events-web/src/lib.rs
@@ -6,12 +6,17 @@
 //!
 //! It provides lightweight helpers to convert browser events into portable
 //! `ui-events` types you can feed into your input handling. It supports
-//! Pointer Events (mouse, touch, pen) and keyboard.
+//! Pointer Events (mouse, touch, pen), keyboard, and text/composition input.
 //!
 //! ## Keyboard
 //!
 //! - [`keyboard::from_web_keyboard_event`]
 //! - Optional helpers: [`keyboard::from_web_keydown_event`], [`keyboard::from_web_keyup_event`]
+//!
+//! ## Text / Composition
+//!
+//! - [`text::text_event_from_dom_event`]
+//! - Typed helpers: [`text::from_web_input_event`], [`text::from_web_composition_event`]
 //!
 //! ## Pointer (Pointer Events)
 //!
@@ -59,6 +64,11 @@
 //!   - Stylus rotation/twist (Pointer Events `twist`) is not currently exposed by `ui-events`,
 //!     so it is not mapped.
 //! - Keyboard: unknown `key`/`code` map to `Unidentified`; `is_composing` reflects the DOM flag.
+//! - Text:
+//!   - `CompositionEvent` maps to composition update/end.
+//!   - `InputEvent` maps committed insertions and simple backward/forward deletion intents.
+//!   - DOM target ranges are node-relative and are not currently converted into `ui-events`
+//!     replacement ranges.
 //!
 //! ## Example
 //!
@@ -112,3 +122,4 @@ extern crate alloc;
 
 pub mod keyboard;
 pub mod pointer;
+pub mod text;

--- a/ui-events-web/src/text.rs
+++ b/ui-events-web/src/text.rs
@@ -1,0 +1,178 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Support routines for converting text-input data from [`web_sys`].
+
+use ui_events::text::{CompositionState, TextInputEvent, TextInsertEvent};
+use web_sys::wasm_bindgen::JsCast;
+use web_sys::{CompositionEvent, Event, InputEvent};
+
+/// Convert a DOM `InputEvent` into a [`TextInputEvent`].
+///
+/// This is intended for `beforeinput` / `input` handlers. It preserves:
+/// - committed insertion text for common `insert*` input types
+/// - delete backward / forward intent
+/// - composition updates when the browser reports `insertCompositionText`
+///
+/// This currently exercises only the common cross-platform subset of
+/// [`TextInputEvent`]. Android-oriented fields such as explicit document
+/// selection updates, surrounding deletes, editor actions, and cursor-placement
+/// metadata remain unset here.
+pub fn from_web_input_event(event: &InputEvent) -> Option<TextInputEvent> {
+    text_event_from_input_type(
+        event.input_type().as_str(),
+        event.data().as_deref(),
+        event.is_composing(),
+    )
+}
+
+/// Convert a DOM `CompositionEvent` into a [`TextInputEvent`].
+///
+/// `compositionstart` currently maps to `None` because `ui-events` does not
+/// have a distinct composition-start event. `compositionupdate` maps to a
+/// composition snapshot, and `compositionend` clears the current composition.
+///
+/// The `data` carried by `compositionend` is not emitted as committed text.
+/// Browsers report the committed text through the paired `beforeinput`/`input`
+/// path, usually as `insertFromComposition`, so consumers should wire both DOM
+/// input events and composition events.
+pub fn from_web_composition_event(event: &CompositionEvent) -> Option<TextInputEvent> {
+    text_event_from_composition_type(event.type_().as_str(), event.data().as_deref())
+}
+
+/// Convert a generic DOM [`Event`] into a [`TextInputEvent`] when it is either
+/// an `InputEvent` or `CompositionEvent`.
+pub fn text_event_from_dom_event(event: &Event) -> Option<TextInputEvent> {
+    if let Some(input) = event.dyn_ref::<InputEvent>() {
+        return from_web_input_event(input);
+    }
+    event
+        .dyn_ref::<CompositionEvent>()
+        .and_then(from_web_composition_event)
+}
+
+/// Convert raw DOM input-event fields into a [`TextInputEvent`].
+pub fn text_event_from_input_type(
+    input_type: &str,
+    data: Option<&str>,
+    is_composing: bool,
+) -> Option<TextInputEvent> {
+    match input_type {
+        "deleteContentBackward" => Some(TextInputEvent::DeleteBackward),
+        "deleteContentForward" => Some(TextInputEvent::DeleteForward),
+        "insertCompositionText" => Some(TextInputEvent::CompositionUpdate(CompositionState::new(
+            data.unwrap_or_default(),
+        ))),
+        "insertText"
+        | "insertReplacementText"
+        | "insertLineBreak"
+        | "insertParagraph"
+        | "insertFromComposition"
+        | "insertFromPaste"
+        | "insertFromDrop" => {
+            let text = data?;
+            if text.is_empty() {
+                None
+            } else if is_composing {
+                Some(TextInputEvent::CompositionUpdate(CompositionState::new(
+                    text,
+                )))
+            } else {
+                Some(TextInputEvent::Insert(TextInsertEvent::new(text)))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Convert raw DOM composition-event fields into a [`TextInputEvent`].
+///
+/// `compositionend` data is intentionally discarded here; committed text comes
+/// from the DOM input-event path.
+pub fn text_event_from_composition_type(
+    event_type: &str,
+    data: Option<&str>,
+) -> Option<TextInputEvent> {
+    match event_type {
+        "compositionstart" => None,
+        "compositionupdate" => Some(TextInputEvent::CompositionUpdate(CompositionState::new(
+            data.unwrap_or_default(),
+        ))),
+        "compositionend" => Some(TextInputEvent::CompositionEnd),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn input_insert_maps_to_text_insert() {
+        assert_eq!(
+            text_event_from_input_type("insertText", Some("é"), false),
+            Some(TextInputEvent::Insert(TextInsertEvent::new("é")))
+        );
+    }
+
+    #[test]
+    fn input_composition_maps_to_snapshot() {
+        assert_eq!(
+            text_event_from_input_type("insertCompositionText", Some("ni"), true),
+            Some(TextInputEvent::CompositionUpdate(CompositionState::new(
+                "ni"
+            )))
+        );
+    }
+
+    #[test]
+    fn input_delete_maps_to_delete_intent() {
+        assert_eq!(
+            text_event_from_input_type("deleteContentBackward", None, false),
+            Some(TextInputEvent::DeleteBackward)
+        );
+        assert_eq!(
+            text_event_from_input_type("deleteContentForward", None, false),
+            Some(TextInputEvent::DeleteForward)
+        );
+    }
+
+    #[test]
+    fn composition_events_map_to_update_and_end() {
+        assert_eq!(
+            text_event_from_composition_type("compositionupdate", Some("に")),
+            Some(TextInputEvent::CompositionUpdate(CompositionState::new(
+                "に"
+            )))
+        );
+        assert_eq!(
+            text_event_from_composition_type("compositionend", Some("に")),
+            Some(TextInputEvent::CompositionEnd)
+        );
+    }
+
+    #[test]
+    fn web_does_not_populate_android_specific_text_fields() {
+        match text_event_from_input_type("insertText", Some("é"), false) {
+            Some(TextInputEvent::Insert(insert)) => {
+                assert_eq!(insert.replacement_range, None);
+                assert_eq!(
+                    insert.cursor_placement,
+                    ui_events::text::TextCursorPlacement::Unspecified
+                );
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+
+        match text_event_from_input_type("insertCompositionText", Some("ni"), true) {
+            Some(TextInputEvent::CompositionUpdate(state)) => {
+                assert_eq!(state.replacement_range, None);
+                assert_eq!(
+                    state.cursor_placement,
+                    ui_events::text::TextCursorPlacement::Unspecified
+                );
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+}

--- a/ui-events-winit/CHANGELOG.md
+++ b/ui-events-winit/CHANGELOG.md
@@ -19,6 +19,10 @@ This release has an [MSRV][] of 1.85.
 
 * Changed `WindowEventReducer::reduce` to require a caller-provided monotonic nanosecond timestamp. Hosts should pass their frame/timer clock timestamp so pointer events are emitted in the same clock domain as frame sampling and timers.
 
+### Added
+
+* Added `WindowEvent::Ime` translation to `ui_events::text::TextInputEvent`.
+
 ### Removed
 
 * Removed the `ui_events_winit::Instant` re-export and the inert `std` feature. `ui-events-winit` no longer owns a reducer-local clock.

--- a/ui-events-winit/README.md
+++ b/ui-events-winit/README.md
@@ -25,7 +25,7 @@ See https://linebender.org/blog/doc-include/ for related discussion. -->
 [`WindowEventReducer`]: https://docs.rs/ui-events-winit/latest/ui_events_winit/struct.WindowEventReducer.html
 <!-- cargo-rdme start -->
 
-This crate bridges [`winit`]'s native input events (mouse, touch, keyboard, etc.)
+This crate bridges [`winit`]'s native input events (mouse, touch, keyboard, IME, etc.)
 into the [`ui-events`] model.
 
 The primary entry point is [`WindowEventReducer`].

--- a/ui-events-winit/src/lib.rs
+++ b/ui-events-winit/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2025 the UI Events Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! This crate bridges [`winit`]'s native input events (mouse, touch, keyboard, etc.)
+//! This crate bridges [`winit`]'s native input events (mouse, touch, keyboard, IME, etc.)
 //! into the [`ui-events`] model.
 //!
 //! The primary entry point is [`WindowEventReducer`].
@@ -28,6 +28,7 @@
 
 pub mod keyboard;
 pub mod pointer;
+pub mod text;
 
 extern crate alloc;
 use alloc::{vec, vec::Vec};
@@ -39,9 +40,10 @@ use ui_events::{
         PointerButtonEvent, PointerEvent, PointerGesture, PointerGestureEvent, PointerId,
         PointerInfo, PointerScrollEvent, PointerState, PointerType, PointerUpdate,
     },
+    text::TextInputEvent,
 };
 use winit::{
-    event::{ElementState, Force, MouseScrollDelta, Touch, TouchPhase, WindowEvent},
+    event::{ElementState, Force, Ime, MouseScrollDelta, Touch, TouchPhase, WindowEvent},
     keyboard::ModifiersState,
 };
 
@@ -49,11 +51,13 @@ use winit::{
 ///
 /// Store a single instance of this per window, then call [`WindowEventReducer::reduce`]
 /// on each [`WindowEvent`] for that window.
-/// Use the [`WindowEventTranslation`] value to receive [`PointerEvent`]s and [`KeyboardEvent`]s.
+/// Use the [`WindowEventTranslation`] value to receive [`PointerEvent`],
+/// [`KeyboardEvent`], and text-input event batches.
 ///
 /// This handles:
 ///  - [`ModifiersChanged`][`WindowEvent::ModifiersChanged`]
 ///  - [`KeyboardInput`][`WindowEvent::KeyboardInput`]
+///  - [`Ime`][`WindowEvent::Ime`]
 ///  - [`Touch`][`WindowEvent::Touch`]
 ///  - [`MouseInput`][`WindowEvent::MouseInput`]
 ///  - [`MouseWheel`][`WindowEvent::MouseWheel`]
@@ -70,6 +74,8 @@ pub struct WindowEventReducer {
     primary_state: PointerState,
     /// Click and tap counter.
     counter: TapCounter,
+    /// Whether the window currently has a non-empty IME composition.
+    ime_composing: bool,
     /// Last caller-provided timestamp seen by the reducer.
     last_seen_time: Option<u64>,
 }
@@ -122,6 +128,21 @@ impl WindowEventReducer {
             WindowEvent::KeyboardInput { event, .. } => Some(WindowEventTranslation::Keyboard(
                 keyboard::from_winit_keyboard_event(event.clone(), self.modifiers),
             )),
+            WindowEvent::Ime(Ime::Enabled) => None,
+            WindowEvent::Ime(Ime::Disabled) => self.end_ime_composition(),
+            WindowEvent::Ime(Ime::Preedit(text, _)) if text.is_empty() => {
+                self.end_ime_composition()
+            }
+            WindowEvent::Ime(ime) => {
+                let was_composing = self.ime_composing;
+                self.ime_composing = matches!(ime, Ime::Preedit(text, _) if !text.is_empty());
+                text::from_winit_ime(ime).map(|mut events| {
+                    if was_composing && matches!(ime, Ime::Commit(_)) {
+                        events.insert(0, TextInputEvent::CompositionEnd);
+                    }
+                    WindowEventTranslation::Text(events)
+                })
+            }
             WindowEvent::CursorEntered { .. } => Some(WindowEventTranslation::Pointer(
                 PointerEvent::Enter(PRIMARY_MOUSE),
             )),
@@ -267,6 +288,17 @@ impl WindowEventReducer {
         }
     }
 
+    fn end_ime_composition(&mut self) -> Option<WindowEventTranslation> {
+        if self.ime_composing {
+            self.ime_composing = false;
+            Some(WindowEventTranslation::Text(vec![
+                TextInputEvent::CompositionEnd,
+            ]))
+        } else {
+            None
+        }
+    }
+
     fn check_time_monotonic(&mut self, time: u64) {
         if let Some(previous) = self.last_seen_time {
             debug_assert!(
@@ -285,6 +317,13 @@ pub enum WindowEventTranslation {
     Keyboard(KeyboardEvent),
     /// Resulting [`PointerEvent`].
     Pointer(PointerEvent),
+    /// Resulting [`TextInputEvent`] values.
+    ///
+    /// This is a batch because one platform event can map to more than one
+    /// normalized text event. For example, committing an active IME
+    /// composition emits [`TextInputEvent::CompositionEnd`] followed by the
+    /// committed [`TextInputEvent::Insert`].
+    Text(Vec<TextInputEvent>),
 }
 
 #[derive(Clone, Debug)]
@@ -456,6 +495,76 @@ mod tests {
     use winit::event::{DeviceId, MouseButton};
 
     use super::*;
+
+    #[test]
+    fn ime_commit_maps_to_text_insert() {
+        let mut reducer = WindowEventReducer::default();
+        assert!(matches!(
+            reducer.reduce(1.0, &WindowEvent::Ime(Ime::Commit("é".into())), 1),
+            Some(WindowEventTranslation::Text(events))
+                if matches!(events.as_slice(), [TextInputEvent::Insert(text)] if text.text == "é")
+        ));
+    }
+
+    #[test]
+    fn ime_commit_ends_active_composition_before_insert() {
+        let mut reducer = WindowEventReducer::default();
+        reducer.reduce(
+            1.0,
+            &WindowEvent::Ime(Ime::Preedit("ni".into(), Some((2, 2)))),
+            1,
+        );
+        assert!(matches!(
+            reducer.reduce(1.0, &WindowEvent::Ime(Ime::Commit("に".into())), 2),
+            Some(WindowEventTranslation::Text(events))
+                if matches!(
+                    events.as_slice(),
+                    [
+                        TextInputEvent::CompositionEnd,
+                        TextInputEvent::Insert(text),
+                    ] if text.text == "に"
+                )
+        ));
+    }
+
+    #[test]
+    fn ime_preedit_maps_to_composition_update() {
+        let mut reducer = WindowEventReducer::default();
+        assert!(matches!(
+            reducer.reduce(
+                1.0,
+                &WindowEvent::Ime(Ime::Preedit("ni".into(), Some((2, 2)))),
+                1,
+            ),
+            Some(WindowEventTranslation::Text(events))
+                if matches!(
+                    events.as_slice(),
+                    [TextInputEvent::CompositionUpdate(state)]
+                        if state.text == "ni"
+                            && state.selection == Some(ui_events::text::TextRange::new(2, 2))
+                )
+        ));
+    }
+
+    #[test]
+    fn ime_disabled_ends_active_composition_once() {
+        let mut reducer = WindowEventReducer::default();
+        reducer.reduce(
+            1.0,
+            &WindowEvent::Ime(Ime::Preedit("ni".into(), Some((2, 2)))),
+            1,
+        );
+        assert!(matches!(
+            reducer.reduce(1.0, &WindowEvent::Ime(Ime::Disabled), 2),
+            Some(WindowEventTranslation::Text(events))
+                if matches!(events.as_slice(), [TextInputEvent::CompositionEnd])
+        ));
+        assert!(
+            reducer
+                .reduce(1.0, &WindowEvent::Ime(Ime::Disabled), 3)
+                .is_none()
+        );
+    }
 
     fn device_id() -> DeviceId {
         DeviceId::dummy()

--- a/ui-events-winit/src/text.rs
+++ b/ui-events-winit/src/text.rs
@@ -1,0 +1,106 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Support routines for converting text-input data from [`winit`].
+
+use alloc::{string::ToString, vec, vec::Vec};
+
+use ui_events::text::{CompositionState, TextInputEvent, TextInsertEvent, TextRange};
+use winit::event::Ime;
+
+/// Convert a non-lifecycle [`winit::event::Ime`] payload to text input events.
+///
+/// This maps commit and preedit payloads. Lifecycle notifications such as
+/// [`Ime::Enabled`] and [`Ime::Disabled`] are left to the caller.
+///
+/// `winit` currently exercises only the common cross-platform subset of
+/// [`TextInputEvent`]: committed insertions plus composition updates/end.
+/// Android-oriented fields such as explicit document selection updates,
+/// surrounding deletes, editor actions, and cursor-placement metadata remain
+/// unset here.
+pub fn from_winit_ime(ime: &Ime) -> Option<Vec<TextInputEvent>> {
+    match ime {
+        Ime::Preedit(text, selection) if !text.is_empty() => {
+            let selection = selection.and_then(|(start, end)| {
+                let start = u32::try_from(start).ok()?;
+                let end = u32::try_from(end).ok()?;
+                Some(TextRange::new(start, end))
+            });
+            let state = CompositionState::new(text.to_string());
+            let state = match selection {
+                Some(selection) => state.try_with_selection(selection)?,
+                None => state,
+            };
+            Some(vec![TextInputEvent::CompositionUpdate(state)])
+        }
+        Ime::Preedit(_, _) => Some(vec![TextInputEvent::CompositionEnd]),
+        Ime::Commit(text) if !text.is_empty() => Some(vec![TextInputEvent::Insert(
+            TextInsertEvent::new(text.to_string()),
+        )]),
+        Ime::Commit(_) | Ime::Enabled | Ime::Disabled => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preedit_maps_to_composition_update() {
+        assert_eq!(
+            from_winit_ime(&Ime::Preedit("ni".into(), Some((2, 2)))),
+            Some(vec![TextInputEvent::CompositionUpdate(
+                CompositionState::new("ni").with_selection(TextRange::new(2, 2))
+            )])
+        );
+    }
+
+    #[test]
+    fn empty_preedit_maps_to_composition_end() {
+        assert_eq!(
+            from_winit_ime(&Ime::Preedit("".into(), None)),
+            Some(vec![TextInputEvent::CompositionEnd])
+        );
+    }
+
+    #[test]
+    fn preedit_rejects_invalid_selection_offsets() {
+        assert_eq!(
+            from_winit_ime(&Ime::Preedit("a🙂b".into(), Some((2, 5)))),
+            None
+        );
+    }
+
+    #[test]
+    fn commit_maps_to_insert() {
+        assert_eq!(
+            from_winit_ime(&Ime::Commit("é".into())),
+            Some(vec![TextInputEvent::Insert(TextInsertEvent::new("é"))])
+        );
+    }
+
+    #[test]
+    fn winit_does_not_populate_android_specific_text_fields() {
+        match from_winit_ime(&Ime::Preedit("ni".into(), Some((2, 2)))).as_deref() {
+            Some([TextInputEvent::CompositionUpdate(state)]) => {
+                assert_eq!(state.replacement_range, None);
+                assert_eq!(
+                    state.cursor_placement,
+                    ui_events::text::TextCursorPlacement::Unspecified
+                );
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+
+        match from_winit_ime(&Ime::Commit("é".into())).as_deref() {
+            Some([TextInputEvent::Insert(insert)]) => {
+                assert_eq!(insert.replacement_range, None);
+                assert_eq!(
+                    insert.cursor_placement,
+                    ui_events::text::TextCursorPlacement::Unspecified
+                );
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+}

--- a/ui-events/CHANGELOG.md
+++ b/ui-events/CHANGELOG.md
@@ -16,6 +16,11 @@ You can find its changes [documented below](#030-2026-01-18).
 This release has an [MSRV][] of 1.85.
 
 ### Added
+* Added `ui_events::text` with `TextInputEvent`, `TextInsertEvent`, `CompositionState`, and explicit range metadata for soft-keyboard and IME input.
+* Added `ui_events::edit` with `EditCommandEvent` for semantic editor commands such as movement, deletion, and selection changes.
+* Added explicit text-input events for selection updates, composing regions, surrounding deletion, editor actions, and document-range conversion helpers.
+* Added explicit cursor-placement metadata for text insertion and composition updates.
+* Added `TextInputEvent` convenience constructors for common insert, replace, composition, selection, delete-surrounding, and action cases.
 
 ### Changed
 

--- a/ui-events/README.md
+++ b/ui-events/README.md
@@ -34,6 +34,8 @@ application development.
 - Pointer events: button down/up, move, enter/leave, scroll, gestures
 - Rich pointer state: position, pressure, tilt, contact size, modifiers
 - Keyboard types re-exported from [`keyboard-types`]
+- Text-input events for soft keyboards and IMEs
+- Edit-command events for semantic editor operations
 - A stable vocabulary you can adapt from windowing backends
 
 This crate is intentionally focused on data structures — it does not open

--- a/ui-events/src/edit.rs
+++ b/ui-events/src/edit.rs
@@ -1,0 +1,233 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! # Edit command event types
+//!
+//! This module contains transport-agnostic editing commands such as cursor
+//! movement, deletion, and selection operations.
+//!
+//! These events are intentionally separate from
+//! [`crate::keyboard::KeyboardEvent`] and [`crate::text::TextInputEvent`]:
+//!
+//! - Keyboard events represent key transitions and shortcuts.
+//! - Text events represent committed text, composition updates, and text-input
+//!   deletion requests.
+//! - Edit commands represent semantic editor actions such as moving the caret,
+//!   deleting a word, or selecting all content.
+//!
+//! This maps especially well to AppKit's `NSStandardKeyBindingResponding`
+//! protocol and `doCommandBySelector:` callbacks, where the platform
+//! communicates editing intent directly rather than sending a physical key
+//! transition or committed text payload.
+//!
+//! ## Deletion routing
+//!
+//! Plain backward/forward deletion may be reported through either a text-input
+//! path or a resolved editor-command path, so it exists in both
+//! [`crate::text::TextInputEvent`] and [`EditCommandEvent`], mirroring the
+//! authoritative platform source. Richer deletes such as word, line, and
+//! paragraph deletion live only on [`EditCommandEvent`].
+//!
+//! Adapters must emit deletion through exactly one event family per platform
+//! action. They should choose the family matching the authoritative platform
+//! callback, and must not additionally mutate from the corresponding
+//! [`crate::keyboard::KeyboardEvent`]. For example, AppKit
+//! `deleteBackward:`/`deleteForward:` delivered through `doCommandBySelector:`
+//! map to [`EditCommandEvent::DeleteBackward`] and
+//! [`EditCommandEvent::DeleteForward`]. Hosts observing multiple channels
+//! should treat the text/edit callback as authoritative over the raw key event.
+
+/// A semantic editing command.
+///
+/// These commands are higher-level than physical key events and lower-level
+/// than any particular text-editor implementation.
+///
+/// The current variants intentionally mirror the subset of AppKit standard
+/// key-binding commands from `NSStandardKeyBindingResponding` that
+/// `ui-events` currently models.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum EditCommandEvent {
+    /// Move backward in the current text direction.
+    MoveBackward,
+    /// Extend the selection while moving backward.
+    MoveBackwardAndModifySelection,
+    /// Move forward in the current text direction.
+    MoveForward,
+    /// Extend the selection while moving forward.
+    MoveForwardAndModifySelection,
+    /// Move to the visual left.
+    MoveLeft,
+    /// Extend the selection while moving to the visual left.
+    MoveLeftAndModifySelection,
+    /// Move to the visual right.
+    MoveRight,
+    /// Extend the selection while moving to the visual right.
+    MoveRightAndModifySelection,
+    /// Move upward.
+    MoveUp,
+    /// Extend the selection while moving upward.
+    MoveUpAndModifySelection,
+    /// Move downward.
+    MoveDown,
+    /// Extend the selection while moving downward.
+    MoveDownAndModifySelection,
+    /// Move backward by one word.
+    MoveWordBackward,
+    /// Extend the selection while moving backward by one word.
+    MoveWordBackwardAndModifySelection,
+    /// Move forward by one word.
+    MoveWordForward,
+    /// Extend the selection while moving forward by one word.
+    MoveWordForwardAndModifySelection,
+    /// Move one word to the visual left.
+    MoveWordLeft,
+    /// Extend the selection while moving one word to the visual left.
+    MoveWordLeftAndModifySelection,
+    /// Move one word to the visual right.
+    MoveWordRight,
+    /// Extend the selection while moving one word to the visual right.
+    MoveWordRightAndModifySelection,
+    /// Move to the beginning of the current line.
+    MoveToBeginningOfLine,
+    /// Extend the selection while moving to the beginning of the current line.
+    MoveToBeginningOfLineAndModifySelection,
+    /// Move to the end of the current line.
+    MoveToEndOfLine,
+    /// Extend the selection while moving to the end of the current line.
+    MoveToEndOfLineAndModifySelection,
+    /// Move to the left edge of the current line.
+    MoveToLeftEndOfLine,
+    /// Extend the selection while moving to the left edge of the current line.
+    MoveToLeftEndOfLineAndModifySelection,
+    /// Move to the right edge of the current line.
+    MoveToRightEndOfLine,
+    /// Extend the selection while moving to the right edge of the current line.
+    MoveToRightEndOfLineAndModifySelection,
+    /// Move to the beginning of the current paragraph.
+    MoveToBeginningOfParagraph,
+    /// Extend the selection while moving to the beginning of the current paragraph.
+    MoveToBeginningOfParagraphAndModifySelection,
+    /// Move to the end of the current paragraph.
+    MoveToEndOfParagraph,
+    /// Extend the selection while moving to the end of the current paragraph.
+    MoveToEndOfParagraphAndModifySelection,
+    /// Move one paragraph backward while extending the selection.
+    MoveParagraphBackwardAndModifySelection,
+    /// Move one paragraph forward while extending the selection.
+    MoveParagraphForwardAndModifySelection,
+    /// Move to the beginning of the document.
+    MoveToBeginningOfDocument,
+    /// Extend the selection while moving to the beginning of the document.
+    MoveToBeginningOfDocumentAndModifySelection,
+    /// Move to the end of the document.
+    MoveToEndOfDocument,
+    /// Extend the selection while moving to the end of the document.
+    MoveToEndOfDocumentAndModifySelection,
+    /// Move one page upward.
+    PageUp,
+    /// Extend the selection while moving one page upward.
+    PageUpAndModifySelection,
+    /// Move one page downward.
+    PageDown,
+    /// Extend the selection while moving one page downward.
+    PageDownAndModifySelection,
+    /// Delete the unit before the insertion point.
+    ///
+    /// This is a deliberate overlap with
+    /// [`crate::text::TextInputEvent::DeleteBackward`] for platforms that
+    /// report plain deletion as a resolved editor command.
+    DeleteBackward,
+    /// Delete backward while decomposing the previous character cluster.
+    DeleteBackwardByDecomposingPreviousCharacter,
+    /// Delete the unit after the insertion point.
+    ///
+    /// This is a deliberate overlap with
+    /// [`crate::text::TextInputEvent::DeleteForward`] for platforms that report
+    /// plain deletion as a resolved editor command.
+    DeleteForward,
+    /// Delete the previous word.
+    DeleteWordBackward,
+    /// Delete the next word.
+    DeleteWordForward,
+    /// Delete to the beginning of the current line.
+    DeleteToBeginningOfLine,
+    /// Delete to the beginning of the current paragraph.
+    DeleteToBeginningOfParagraph,
+    /// Delete to the end of the current line.
+    DeleteToEndOfLine,
+    /// Delete to the end of the current paragraph.
+    DeleteToEndOfParagraph,
+    /// Insert a back-tab.
+    InsertBacktab,
+    /// Insert a line break.
+    InsertLineBreak,
+    /// Insert a newline.
+    InsertNewline,
+    /// Insert a paragraph separator.
+    InsertParagraphSeparator,
+    /// Insert a tab.
+    InsertTab,
+    /// Insert a literal double quote without substitution.
+    InsertDoubleQuoteIgnoringSubstitution,
+    /// Insert a literal single quote without substitution.
+    InsertSingleQuoteIgnoringSubstitution,
+    /// Select all content.
+    SelectAll,
+    /// Select the current line.
+    SelectLine,
+    /// Select the current paragraph.
+    SelectParagraph,
+    /// Select the current word.
+    SelectWord,
+    /// Scroll one line upward.
+    ScrollLineUp,
+    /// Scroll one line downward.
+    ScrollLineDown,
+    /// Scroll one page upward.
+    ScrollPageUp,
+    /// Scroll one page downward.
+    ScrollPageDown,
+    /// Scroll to the beginning of the document.
+    ScrollToBeginningOfDocument,
+    /// Scroll to the end of the document.
+    ScrollToEndOfDocument,
+    /// Center the selection in the visible area.
+    CenterSelectionInVisibleArea,
+    /// Transpose adjacent units.
+    Transpose,
+    /// Capitalize the current word.
+    CapitalizeWord,
+    /// Lowercase the current word.
+    LowercaseWord,
+    /// Uppercase the current word.
+    UppercaseWord,
+    /// Request completion for the current editing context.
+    Complete,
+    /// Cancel the current editing operation.
+    CancelOperation,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EditCommandEvent;
+
+    #[test]
+    fn edit_commands_are_copy_and_comparable() {
+        let command = EditCommandEvent::MoveWordForwardAndModifySelection;
+        let copied = command;
+        assert_eq!(copied, EditCommandEvent::MoveWordForwardAndModifySelection);
+    }
+
+    #[test]
+    fn plain_delete_commands_are_deliberate_overlap() {
+        assert_eq!(
+            EditCommandEvent::DeleteBackward,
+            EditCommandEvent::DeleteBackward
+        );
+        assert_eq!(
+            EditCommandEvent::DeleteForward,
+            EditCommandEvent::DeleteForward
+        );
+    }
+}

--- a/ui-events/src/lib.rs
+++ b/ui-events/src/lib.rs
@@ -13,6 +13,8 @@
 //! - Pointer events: button down/up, move, enter/leave, scroll, gestures
 //! - Rich pointer state: position, pressure, tilt, contact size, modifiers
 //! - Keyboard types re-exported from [`keyboard-types`]
+//! - Text-input events for soft keyboards and IMEs
+//! - Edit-command events for semantic editor operations
 //! - A stable vocabulary you can adapt from windowing backends
 //!
 //! This crate is intentionally focused on data structures — it does not open
@@ -121,9 +123,12 @@
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
 #![no_std]
+extern crate alloc;
 
+pub mod edit;
 pub mod keyboard;
 pub mod pointer;
+pub mod text;
 
 mod scroll;
 

--- a/ui-events/src/text.rs
+++ b/ui-events/src/text.rs
@@ -1,0 +1,914 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! # Text input event types
+//!
+//! This module contains transport-agnostic text-input events for soft keyboards
+//! and input methods.
+//!
+//! These events are intentionally separate from
+//! [`crate::keyboard::KeyboardEvent`]. Keyboard events represent key transitions
+//! and shortcuts; text events represent editing intent such as committed text,
+//! deletion, and composition updates.
+//!
+//! Plain backward/forward deletion can also appear as
+//! [`crate::edit::EditCommandEvent`] when a platform reports the action through
+//! a resolved editor-command callback. See [`crate::edit`] for the adapter
+//! routing contract.
+//!
+//! ## Design notes
+//!
+//! - Text events do not own your text buffer or selection state.
+//! - Text events do not imply any physical key identity.
+//! - Composition updates are snapshots of the current composing text.
+//! - Selection within a composition string uses UTF-8 byte offsets so it can
+//!   be sliced directly from Rust strings.
+//! - Replacement ranges carry an explicit offset encoding because platforms do
+//!   not agree on document indexing units.
+//! - `CompositionState::selection` is normalized to UTF-8 byte offsets because
+//!   the composing string is carried in the event itself. `TextTargetRange`
+//!   keeps its source encoding because it refers to positions in the editor's
+//!   document, and `ui-events` does not own the full document text needed to
+//!   normalize those offsets safely.
+//! - Some platforms, notably Android, also report explicit selection changes,
+//!   composing regions, surrounding-delete operations, and editor actions.
+//! - Cursor placement after text insertion or composition updates is optional
+//!   metadata because some platforms, notably Android, expose it explicitly
+//!   while others do not.
+
+use alloc::string::String;
+use core::ops::Range;
+
+/// A half-open text range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TextRange {
+    /// Inclusive start offset.
+    pub start: u32,
+    /// Exclusive end offset.
+    pub end: u32,
+}
+
+impl TextRange {
+    /// Create a range from explicit offsets.
+    pub const fn new(start: u32, end: u32) -> Self {
+        Self { start, end }
+    }
+}
+
+/// The offset encoding used by a platform-provided document range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TextRangeEncoding {
+    /// Offsets are UTF-8 byte indices.
+    Utf8Bytes,
+    /// Offsets are UTF-16 code-unit indices.
+    Utf16CodeUnits,
+    /// Offsets are Unicode code-point indices.
+    UnicodeCodePoints,
+}
+
+/// A platform-provided document range and its offset encoding.
+///
+/// Platform provenance:
+/// - Apple text APIs commonly use UTF-16 code-unit indices.
+/// - Android text APIs may use either UTF-16 code units or Unicode code points.
+/// - Wayland text-input uses UTF-8 byte indices.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TextTargetRange {
+    /// The underlying range offsets.
+    pub range: TextRange,
+    /// The encoding used by the platform for those offsets.
+    pub encoding: TextRangeEncoding,
+}
+
+impl TextTargetRange {
+    /// Construct a range whose offsets are UTF-8 byte indices.
+    pub const fn utf8_bytes(start: u32, end: u32) -> Self {
+        Self {
+            range: TextRange::new(start, end),
+            encoding: TextRangeEncoding::Utf8Bytes,
+        }
+    }
+
+    /// Construct a range whose offsets are UTF-16 code-unit indices.
+    pub const fn utf16_code_units(start: u32, end: u32) -> Self {
+        Self {
+            range: TextRange::new(start, end),
+            encoding: TextRangeEncoding::Utf16CodeUnits,
+        }
+    }
+
+    /// Construct a range whose offsets are Unicode code-point indices.
+    pub const fn unicode_code_points(start: u32, end: u32) -> Self {
+        Self {
+            range: TextRange::new(start, end),
+            encoding: TextRangeEncoding::UnicodeCodePoints,
+        }
+    }
+
+    /// Convert this platform-provided range into UTF-8 byte offsets for `text`.
+    ///
+    /// Returns `None` when the source offsets are out of bounds, reversed, or
+    /// do not land on valid character boundaries for the given encoding.
+    pub fn to_utf8_range_in(self, text: &str) -> Option<TextRange> {
+        let start = self.offset_to_utf8(text, self.range.start)?;
+        let end = self.offset_to_utf8(text, self.range.end)?;
+        (start <= end).then_some(TextRange::new(start, end))
+    }
+
+    /// Convert this platform-provided range into a Rust string slice range.
+    ///
+    /// Returns `None` when the source offsets are out of bounds, reversed, or
+    /// do not land on valid character boundaries for the given encoding.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use ui_events::text::TextTargetRange;
+    ///
+    /// let mut text = String::from("a🙂b");
+    /// let range = TextTargetRange::utf16_code_units(1, 3)
+    ///     .to_range_in(&text)
+    ///     .expect("valid UTF-16 range");
+    /// text.replace_range(range, "x");
+    ///
+    /// assert_eq!(text, "axb");
+    /// ```
+    pub fn to_range_in(self, text: &str) -> Option<Range<usize>> {
+        let range = self.to_utf8_range_in(text)?;
+        Some(range.start as usize..range.end as usize)
+    }
+
+    fn offset_to_utf8(self, text: &str, offset: u32) -> Option<u32> {
+        match self.encoding {
+            TextRangeEncoding::Utf8Bytes => utf8_offset_to_utf8_byte_offset(text, offset),
+            TextRangeEncoding::Utf16CodeUnits => utf16_offset_to_utf8_byte_offset(text, offset),
+            TextRangeEncoding::UnicodeCodePoints => {
+                code_point_offset_to_utf8_byte_offset(text, offset)
+            }
+        }
+    }
+}
+
+fn utf8_offset_to_utf8_byte_offset(text: &str, utf8_offset: u32) -> Option<u32> {
+    let offset = usize::try_from(utf8_offset).ok()?;
+    (offset <= text.len() && text.is_char_boundary(offset)).then_some(utf8_offset)
+}
+
+fn utf16_offset_to_utf8_byte_offset(text: &str, utf16_offset: u32) -> Option<u32> {
+    if utf16_offset == 0 {
+        return Some(0);
+    }
+    let target = usize::try_from(utf16_offset).ok()?;
+    let mut utf16_count = 0_usize;
+    for (byte_offset, ch) in text.char_indices() {
+        utf16_count = utf16_count.checked_add(ch.len_utf16())?;
+        if utf16_count == target {
+            let byte_offset = byte_offset.checked_add(ch.len_utf8())?;
+            return u32::try_from(byte_offset).ok();
+        }
+    }
+    (utf16_count == target)
+        .then(|| u32::try_from(text.len()).ok())
+        .flatten()
+}
+
+fn code_point_offset_to_utf8_byte_offset(text: &str, code_point_offset: u32) -> Option<u32> {
+    if code_point_offset == 0 {
+        return Some(0);
+    }
+    let target = usize::try_from(code_point_offset).ok()?;
+    let mut code_point_count = 0_usize;
+    for (byte_offset, _) in text.char_indices() {
+        if code_point_count == target {
+            return u32::try_from(byte_offset).ok();
+        }
+        code_point_count = code_point_count.checked_add(1)?;
+    }
+    (code_point_count == target)
+        .then(|| u32::try_from(text.len()).ok())
+        .flatten()
+}
+
+/// A committed text insertion.
+///
+/// This is the common committed-text path used by web, winit, and Apple text
+/// adapters. Android-style adapters may additionally populate
+/// [`replacement_range`](Self::replacement_range) and
+/// [`cursor_placement`](Self::cursor_placement).
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TextInsertEvent {
+    /// The committed text.
+    pub text: String,
+    /// The document range to replace, when the platform provides one.
+    pub replacement_range: Option<TextTargetRange>,
+    /// Cursor-placement metadata associated with this insertion.
+    pub cursor_placement: TextCursorPlacement,
+}
+
+impl TextInsertEvent {
+    /// Create an insertion event from committed text.
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            replacement_range: None,
+            cursor_placement: TextCursorPlacement::Unspecified,
+        }
+    }
+
+    /// Attach a replacement range to this insertion.
+    pub const fn with_replacement_range(mut self, replacement_range: TextTargetRange) -> Self {
+        self.replacement_range = Some(replacement_range);
+        self
+    }
+
+    /// Attach cursor-placement metadata to this insertion.
+    pub const fn with_cursor_placement(mut self, cursor_placement: TextCursorPlacement) -> Self {
+        self.cursor_placement = cursor_placement;
+        self
+    }
+}
+
+/// A request to delete content around the current selection or insertion point.
+///
+/// The units of `before_length` and `after_length` are determined by
+/// [`Self::encoding`].
+///
+/// This shape exists primarily for Android-style text protocols such as
+/// `InputConnection::deleteSurroundingText`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TextDeleteSurroundingEvent {
+    /// The number of units to delete before the insertion point.
+    pub before_length: u32,
+    /// The number of units to delete after the insertion point.
+    pub after_length: u32,
+    /// The encoding used for both lengths.
+    pub encoding: TextRangeEncoding,
+}
+
+impl TextDeleteSurroundingEvent {
+    /// Construct a surrounding-delete request in UTF-8 byte units.
+    pub const fn utf8_bytes(before_length: u32, after_length: u32) -> Self {
+        Self {
+            before_length,
+            after_length,
+            encoding: TextRangeEncoding::Utf8Bytes,
+        }
+    }
+
+    /// Construct a surrounding-delete request in UTF-16 code units.
+    pub const fn utf16_code_units(before_length: u32, after_length: u32) -> Self {
+        Self {
+            before_length,
+            after_length,
+            encoding: TextRangeEncoding::Utf16CodeUnits,
+        }
+    }
+
+    /// Construct a surrounding-delete request in Unicode code points.
+    pub const fn unicode_code_points(before_length: u32, after_length: u32) -> Self {
+        Self {
+            before_length,
+            after_length,
+            encoding: TextRangeEncoding::UnicodeCodePoints,
+        }
+    }
+}
+
+/// A semantic editor action requested by the platform text system.
+///
+/// This is primarily for Android-style IME action buttons such as "done",
+/// "next", and "search".
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TextInputAction {
+    /// Submit the current field with a "done" action.
+    Done,
+    /// Submit the current field with a "go" action.
+    Go,
+    /// Move focus to the next field.
+    Next,
+    /// Move focus to the previous field.
+    Previous,
+    /// Submit the current field with a "search" action.
+    Search,
+    /// Submit the current field with a "send" action.
+    Send,
+    /// Insert a newline as the preferred editor action.
+    Newline,
+}
+
+/// Cursor placement associated with a text insertion or composition update.
+///
+/// This is optional because Android exposes explicit cursor-placement metadata,
+/// while the currently modeled web, winit, and Apple adapters do not.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
+pub enum TextCursorPlacement {
+    /// The platform did not specify cursor placement metadata.
+    #[default]
+    Unspecified,
+    /// The platform specified a relative cursor offset.
+    Offset(TextCursorOffset),
+}
+
+/// A relative cursor offset associated with inserted or composing text.
+///
+/// This currently exists to preserve Android cursor-placement semantics.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TextCursorOffset {
+    /// The offset value in the units specified by [`Self::encoding`].
+    pub value: i32,
+    /// The encoding used by `value`.
+    pub encoding: TextRangeEncoding,
+    /// The anchor point from which `value` is interpreted.
+    pub relative_to: TextCursorAnchor,
+}
+
+impl TextCursorOffset {
+    /// Construct a cursor offset with explicit encoding and anchor metadata.
+    pub const fn new(
+        value: i32,
+        encoding: TextRangeEncoding,
+        relative_to: TextCursorAnchor,
+    ) -> Self {
+        Self {
+            value,
+            encoding,
+            relative_to,
+        }
+    }
+
+    /// Construct a UTF-8 byte cursor offset.
+    pub const fn utf8_bytes(value: i32, relative_to: TextCursorAnchor) -> Self {
+        Self::new(value, TextRangeEncoding::Utf8Bytes, relative_to)
+    }
+
+    /// Construct a UTF-16 code-unit cursor offset.
+    pub const fn utf16_code_units(value: i32, relative_to: TextCursorAnchor) -> Self {
+        Self::new(value, TextRangeEncoding::Utf16CodeUnits, relative_to)
+    }
+
+    /// Construct a Unicode code-point cursor offset.
+    pub const fn unicode_code_points(value: i32, relative_to: TextCursorAnchor) -> Self {
+        Self::new(value, TextRangeEncoding::UnicodeCodePoints, relative_to)
+    }
+}
+
+/// The anchor point for interpreting a relative cursor offset.
+///
+/// These anchors are chosen to describe Android-style relative cursor placement
+/// without forcing adapters that do not expose such metadata to invent values.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TextCursorAnchor {
+    /// Relative to the start of the inserted or composing text.
+    InsertedTextStart,
+    /// Relative to the end of the inserted or composing text.
+    InsertedTextEnd,
+    /// Relative to the start of the replaced document range.
+    ReplacedRangeStart,
+    /// Relative to the end of the replaced document range.
+    ReplacedRangeEnd,
+}
+
+/// A snapshot of the current composition text.
+///
+/// This is emitted while an IME or soft keyboard is building text that has not
+/// yet been committed to the underlying editor content.
+///
+/// This is the common composition/preedit path used by web, winit, and Apple
+/// text adapters. Android-style adapters may additionally populate
+/// [`replacement_range`](Self::replacement_range) and
+/// [`cursor_placement`](Self::cursor_placement).
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompositionState {
+    /// The current composition text.
+    pub text: String,
+    /// The selection within `text`, expressed as UTF-8 byte offsets.
+    pub selection: Option<TextRange>,
+    /// The document range to replace, when the platform provides one.
+    pub replacement_range: Option<TextTargetRange>,
+    /// Cursor-placement metadata associated with this composition update.
+    pub cursor_placement: TextCursorPlacement,
+}
+
+impl CompositionState {
+    /// Create a composition snapshot from the provided text.
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            selection: None,
+            replacement_range: None,
+            cursor_placement: TextCursorPlacement::Unspecified,
+        }
+    }
+
+    /// Attach a selection within the composing text.
+    ///
+    /// `selection` must be ordered, in bounds for [`Self::text`], and land on
+    /// UTF-8 character boundaries. Use [`Self::try_with_selection`] when
+    /// converting unchecked platform offsets.
+    pub fn with_selection(mut self, selection: TextRange) -> Self {
+        debug_assert!(
+            self.is_valid_selection(selection),
+            "composition selection must be ordered, in bounds, and on UTF-8 character boundaries"
+        );
+        self.selection = Some(selection);
+        self
+    }
+
+    /// Try to attach a selection within the composing text.
+    ///
+    /// Returns `None` when `selection` is reversed, out of bounds, or does not
+    /// land on UTF-8 character boundaries in [`Self::text`].
+    pub fn try_with_selection(mut self, selection: TextRange) -> Option<Self> {
+        self.is_valid_selection(selection).then(|| {
+            self.selection = Some(selection);
+            self
+        })
+    }
+
+    /// Attach a replacement range to this composition update.
+    pub const fn with_replacement_range(mut self, replacement_range: TextTargetRange) -> Self {
+        self.replacement_range = Some(replacement_range);
+        self
+    }
+
+    /// Attach cursor-placement metadata to this composition update.
+    pub const fn with_cursor_placement(mut self, cursor_placement: TextCursorPlacement) -> Self {
+        self.cursor_placement = cursor_placement;
+        self
+    }
+
+    fn is_valid_selection(&self, selection: TextRange) -> bool {
+        TextTargetRange::utf8_bytes(selection.start, selection.end)
+            .to_range_in(&self.text)
+            .is_some()
+    }
+}
+
+/// A text-input event.
+///
+/// These events represent editing intent, not physical key transitions.
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TextInputEvent {
+    /// Insert committed text at the current insertion point or selection.
+    ///
+    /// The text may contain multiple Unicode scalar values or grapheme
+    /// clusters, for example when committing emoji or multi-character IME
+    /// output.
+    Insert(TextInsertEvent),
+    /// Delete content immediately before the insertion point.
+    DeleteBackward,
+    /// Delete content immediately after the insertion point.
+    DeleteForward,
+    /// Delete content surrounding the current insertion point or selection.
+    ///
+    /// Primarily produced by Android-style text protocols.
+    DeleteSurrounding(TextDeleteSurroundingEvent),
+    /// Update the document selection range.
+    ///
+    /// Primarily produced by Android-style text protocols.
+    SetSelection(TextTargetRange),
+    /// Update the current composing region in the document.
+    ///
+    /// Primarily produced by Android-style text protocols.
+    SetComposingRegion(TextTargetRange),
+    /// Update the current composition text.
+    CompositionUpdate(CompositionState),
+    /// Clear the current composition.
+    CompositionEnd,
+    /// Request a semantic editor action such as "search" or "done".
+    ///
+    /// Primarily produced by Android-style text protocols.
+    Action(TextInputAction),
+}
+
+impl TextInputEvent {
+    /// Construct a committed text insertion.
+    pub fn insert(text: impl Into<String>) -> Self {
+        Self::Insert(TextInsertEvent::new(text))
+    }
+
+    /// Construct a committed text insertion with an explicit replacement range.
+    pub fn replace(text: impl Into<String>, replacement_range: TextTargetRange) -> Self {
+        Self::Insert(TextInsertEvent::new(text).with_replacement_range(replacement_range))
+    }
+
+    /// Construct a composition update with no selection or replacement metadata.
+    pub fn composition(text: impl Into<String>) -> Self {
+        Self::CompositionUpdate(CompositionState::new(text))
+    }
+
+    /// Construct a surrounding-delete request in UTF-8 byte units.
+    pub const fn delete_surrounding_utf8(before_length: u32, after_length: u32) -> Self {
+        Self::DeleteSurrounding(TextDeleteSurroundingEvent::utf8_bytes(
+            before_length,
+            after_length,
+        ))
+    }
+
+    /// Construct a surrounding-delete request in UTF-16 code-unit units.
+    pub const fn delete_surrounding_utf16_code_units(
+        before_length: u32,
+        after_length: u32,
+    ) -> Self {
+        Self::DeleteSurrounding(TextDeleteSurroundingEvent::utf16_code_units(
+            before_length,
+            after_length,
+        ))
+    }
+
+    /// Construct a surrounding-delete request in Unicode code-point units.
+    pub const fn delete_surrounding_unicode_code_points(
+        before_length: u32,
+        after_length: u32,
+    ) -> Self {
+        Self::DeleteSurrounding(TextDeleteSurroundingEvent::unicode_code_points(
+            before_length,
+            after_length,
+        ))
+    }
+
+    /// Construct an explicit document selection update.
+    pub const fn set_selection(range: TextTargetRange) -> Self {
+        Self::SetSelection(range)
+    }
+
+    /// Construct an explicit composing-region update.
+    pub const fn set_composing_region(range: TextTargetRange) -> Self {
+        Self::SetComposingRegion(range)
+    }
+
+    /// Construct a semantic editor action.
+    pub const fn action(action: TextInputAction) -> Self {
+        Self::Action(action)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CompositionState, TextCursorAnchor, TextCursorOffset, TextCursorPlacement,
+        TextDeleteSurroundingEvent, TextInputAction, TextInputEvent, TextInsertEvent, TextRange,
+        TextRangeEncoding, TextTargetRange,
+    };
+    use alloc::string::String;
+    use core::ops::Range;
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    struct EditorState {
+        text: String,
+        selection: Option<TextRange>,
+        composing_range: Option<TextRange>,
+    }
+
+    impl EditorState {
+        fn apply(&mut self, event: TextInputEvent) {
+            match event {
+                TextInputEvent::Insert(insert) => {
+                    let replace = insert
+                        .replacement_range
+                        .and_then(|range| range.to_range_in(&self.text))
+                        .or_else(|| self.selection_range());
+                    let insert_len = u32::try_from(insert.text.len()).unwrap();
+                    if let Some(range) = replace {
+                        let start = u32::try_from(range.start).unwrap();
+                        self.text.replace_range(range.clone(), &insert.text);
+                        let end = start + insert_len;
+                        self.selection = Some(TextRange::new(end, end));
+                    } else {
+                        self.text.push_str(&insert.text);
+                        let end = u32::try_from(self.text.len()).unwrap();
+                        self.selection = Some(TextRange::new(end, end));
+                    }
+                    self.composing_range = None;
+                }
+                TextInputEvent::DeleteSurrounding(delete) => {
+                    let selection = self.selection.expect("selection must be set");
+                    assert_eq!(delete.encoding, TextRangeEncoding::Utf8Bytes);
+                    let start = selection.start.saturating_sub(delete.before_length);
+                    let end = selection.end.saturating_add(delete.after_length);
+                    let range = TextRange::new(start, end);
+                    let slice = TextTargetRange::utf8_bytes(range.start, range.end)
+                        .to_range_in(&self.text)
+                        .unwrap();
+                    self.text.replace_range(slice, "");
+                    self.selection = Some(TextRange::new(start, start));
+                    self.composing_range = None;
+                }
+                TextInputEvent::SetSelection(range) => {
+                    self.selection = Some(range.to_utf8_range_in(&self.text).unwrap());
+                }
+                TextInputEvent::SetComposingRegion(range) => {
+                    self.composing_range = Some(range.to_utf8_range_in(&self.text).unwrap());
+                }
+                TextInputEvent::CompositionUpdate(state) => {
+                    let replace = state
+                        .replacement_range
+                        .and_then(|range| range.to_range_in(&self.text))
+                        .or_else(|| self.composing_range_range())
+                        .or_else(|| self.selection_range());
+                    if let Some(range) = replace {
+                        let start = u32::try_from(range.start).unwrap();
+                        self.text.replace_range(range.clone(), &state.text);
+                        let end = start + u32::try_from(state.text.len()).unwrap();
+                        self.composing_range = Some(TextRange::new(start, end));
+                        self.selection = state.selection.map(|selection| {
+                            TextRange::new(start + selection.start, start + selection.end)
+                        });
+                    }
+                }
+                TextInputEvent::CompositionEnd => {
+                    self.composing_range = None;
+                }
+                TextInputEvent::DeleteBackward
+                | TextInputEvent::DeleteForward
+                | TextInputEvent::Action(_) => {}
+            }
+        }
+
+        fn selection_range(&self) -> Option<Range<usize>> {
+            let selection = self.selection?;
+            TextTargetRange::utf8_bytes(selection.start, selection.end).to_range_in(&self.text)
+        }
+
+        fn composing_range_range(&self) -> Option<Range<usize>> {
+            let range = self.composing_range?;
+            TextTargetRange::utf8_bytes(range.start, range.end).to_range_in(&self.text)
+        }
+    }
+
+    #[test]
+    fn insert_text_can_hold_multiple_scalars() {
+        assert_eq!(
+            TextInputEvent::Insert(
+                TextInsertEvent::new("é🙂")
+                    .with_replacement_range(TextTargetRange::utf16_code_units(4, 7))
+            ),
+            TextInputEvent::Insert(
+                TextInsertEvent::new("é🙂")
+                    .with_replacement_range(TextTargetRange::utf16_code_units(4, 7))
+            )
+        );
+    }
+
+    #[test]
+    fn composition_state_preserves_text_selection_and_range() {
+        let state = CompositionState::new("ni")
+            .with_selection(TextRange::new(0, 2))
+            .with_replacement_range(TextTargetRange::utf16_code_units(8, 10));
+        assert_eq!(state.text, "ni");
+        assert_eq!(state.selection, Some(TextRange::new(0, 2)));
+        assert_eq!(
+            state.replacement_range,
+            Some(TextTargetRange::utf16_code_units(8, 10))
+        );
+        assert_eq!(state.cursor_placement, TextCursorPlacement::Unspecified);
+    }
+
+    #[test]
+    fn composition_state_checked_selection_rejects_invalid_ranges() {
+        assert_eq!(
+            CompositionState::new("a🙂b")
+                .try_with_selection(TextRange::new(1, 5))
+                .map(|state| state.selection),
+            Some(Some(TextRange::new(1, 5)))
+        );
+        assert_eq!(
+            CompositionState::new("a🙂b")
+                .try_with_selection(TextRange::new(2, 5))
+                .map(|state| state.selection),
+            None
+        );
+        assert_eq!(
+            CompositionState::new("abc")
+                .try_with_selection(TextRange::new(3, 1))
+                .map(|state| state.selection),
+            None
+        );
+    }
+
+    #[test]
+    fn target_ranges_can_use_code_point_indices() {
+        assert_eq!(
+            TextTargetRange::unicode_code_points(3, 5),
+            TextTargetRange {
+                range: TextRange::new(3, 5),
+                encoding: TextRangeEncoding::UnicodeCodePoints,
+            }
+        );
+    }
+
+    #[test]
+    fn utf8_target_range_validates_char_boundaries() {
+        let text = "a🙂b";
+        assert_eq!(
+            TextTargetRange::utf8_bytes(1, 5).to_utf8_range_in(text),
+            Some(TextRange::new(1, 5))
+        );
+        assert_eq!(
+            TextTargetRange::utf8_bytes(2, 5).to_utf8_range_in(text),
+            None
+        );
+    }
+
+    #[test]
+    fn utf16_target_range_converts_surrogate_pairs() {
+        let text = "a🙂b";
+        assert_eq!(
+            TextTargetRange::utf16_code_units(1, 3).to_utf8_range_in(text),
+            Some(TextRange::new(1, 5))
+        );
+        assert_eq!(
+            TextTargetRange::utf16_code_units(2, 3).to_utf8_range_in(text),
+            None
+        );
+    }
+
+    #[test]
+    fn code_point_target_range_counts_scalars_not_graphemes() {
+        let text = "e\u{301}🙂z";
+        assert_eq!(
+            TextTargetRange::unicode_code_points(0, 2).to_utf8_range_in(text),
+            Some(TextRange::new(0, 3))
+        );
+        assert_eq!(
+            TextTargetRange::unicode_code_points(2, 3).to_utf8_range_in(text),
+            Some(TextRange::new(3, 7))
+        );
+    }
+
+    #[test]
+    fn target_range_rejects_reversed_and_out_of_bounds_offsets() {
+        let text = "abc";
+        assert_eq!(
+            TextTargetRange::utf8_bytes(3, 1).to_utf8_range_in(text),
+            None
+        );
+        assert_eq!(
+            TextTargetRange::utf16_code_units(0, 4).to_utf8_range_in(text),
+            None
+        );
+        assert_eq!(
+            TextTargetRange::unicode_code_points(0, 4).to_utf8_range_in(text),
+            None
+        );
+    }
+
+    #[test]
+    fn target_range_can_be_used_as_rust_slice_range() {
+        let text = "a🙂b";
+        assert_eq!(
+            TextTargetRange::utf16_code_units(1, 3).to_range_in(text),
+            Some(Range { start: 1, end: 5 })
+        );
+    }
+
+    #[test]
+    fn delete_surrounding_event_preserves_lengths_and_encoding() {
+        assert_eq!(
+            TextDeleteSurroundingEvent::unicode_code_points(2, 1),
+            TextDeleteSurroundingEvent {
+                before_length: 2,
+                after_length: 1,
+                encoding: TextRangeEncoding::UnicodeCodePoints,
+            }
+        );
+    }
+
+    #[test]
+    fn text_input_event_covers_android_specific_operations() {
+        assert_eq!(
+            TextInputEvent::DeleteSurrounding(TextDeleteSurroundingEvent::utf16_code_units(3, 2)),
+            TextInputEvent::DeleteSurrounding(TextDeleteSurroundingEvent {
+                before_length: 3,
+                after_length: 2,
+                encoding: TextRangeEncoding::Utf16CodeUnits,
+            })
+        );
+        assert_eq!(
+            TextInputEvent::SetSelection(TextTargetRange::unicode_code_points(4, 6)),
+            TextInputEvent::SetSelection(TextTargetRange {
+                range: TextRange::new(4, 6),
+                encoding: TextRangeEncoding::UnicodeCodePoints,
+            })
+        );
+        assert_eq!(
+            TextInputEvent::SetComposingRegion(TextTargetRange::utf16_code_units(8, 10)),
+            TextInputEvent::SetComposingRegion(TextTargetRange::utf16_code_units(8, 10))
+        );
+        assert_eq!(
+            TextInputEvent::Action(TextInputAction::Search),
+            TextInputEvent::Action(TextInputAction::Search)
+        );
+    }
+
+    #[test]
+    fn text_input_event_convenience_constructors_match_manual_forms() {
+        assert_eq!(
+            TextInputEvent::insert("é"),
+            TextInputEvent::Insert(TextInsertEvent::new("é"))
+        );
+        assert_eq!(
+            TextInputEvent::replace("x", TextTargetRange::utf16_code_units(4, 5)),
+            TextInputEvent::Insert(
+                TextInsertEvent::new("x")
+                    .with_replacement_range(TextTargetRange::utf16_code_units(4, 5))
+            )
+        );
+        assert_eq!(
+            TextInputEvent::composition("ni"),
+            TextInputEvent::CompositionUpdate(CompositionState::new("ni"))
+        );
+        assert_eq!(
+            TextInputEvent::delete_surrounding_utf8(2, 1),
+            TextInputEvent::DeleteSurrounding(TextDeleteSurroundingEvent::utf8_bytes(2, 1))
+        );
+        assert_eq!(
+            TextInputEvent::delete_surrounding_utf16_code_units(2, 1),
+            TextInputEvent::DeleteSurrounding(TextDeleteSurroundingEvent::utf16_code_units(2, 1))
+        );
+        assert_eq!(
+            TextInputEvent::delete_surrounding_unicode_code_points(2, 1),
+            TextInputEvent::DeleteSurrounding(TextDeleteSurroundingEvent::unicode_code_points(
+                2, 1
+            ))
+        );
+        assert_eq!(
+            TextInputEvent::set_selection(TextTargetRange::utf8_bytes(3, 5)),
+            TextInputEvent::SetSelection(TextTargetRange::utf8_bytes(3, 5))
+        );
+        assert_eq!(
+            TextInputEvent::set_composing_region(TextTargetRange::utf16_code_units(8, 10)),
+            TextInputEvent::SetComposingRegion(TextTargetRange::utf16_code_units(8, 10))
+        );
+        assert_eq!(
+            TextInputEvent::action(TextInputAction::Search),
+            TextInputEvent::Action(TextInputAction::Search)
+        );
+    }
+
+    #[test]
+    fn insert_and_composition_events_preserve_cursor_placement() {
+        let placement = TextCursorPlacement::Offset(TextCursorOffset::utf16_code_units(
+            1,
+            TextCursorAnchor::InsertedTextEnd,
+        ));
+        assert_eq!(
+            TextInsertEvent::new("é").with_cursor_placement(placement),
+            TextInsertEvent {
+                text: "é".into(),
+                replacement_range: None,
+                cursor_placement: placement,
+            }
+        );
+        assert_eq!(
+            CompositionState::new("に").with_cursor_placement(placement),
+            CompositionState {
+                text: "に".into(),
+                selection: None,
+                replacement_range: None,
+                cursor_placement: placement,
+            }
+        );
+    }
+
+    #[test]
+    fn editor_state_example_applies_replacement_selection_and_composition() {
+        let mut state = EditorState {
+            text: "hello world".into(),
+            selection: Some(TextRange::new(6, 11)),
+            composing_range: None,
+        };
+
+        state.apply(TextInputEvent::Insert(
+            TextInsertEvent::new("linebender")
+                .with_replacement_range(TextTargetRange::utf8_bytes(6, 11)),
+        ));
+        assert_eq!(state.text, "hello linebender");
+        assert_eq!(state.selection, Some(TextRange::new(16, 16)));
+
+        state.apply(TextInputEvent::SetSelection(TextTargetRange::utf8_bytes(
+            16, 16,
+        )));
+        state.apply(TextInputEvent::DeleteSurrounding(
+            TextDeleteSurroundingEvent::utf8_bytes(10, 0),
+        ));
+        assert_eq!(state.text, "hello ");
+        assert_eq!(state.selection, Some(TextRange::new(6, 6)));
+
+        state.apply(TextInputEvent::SetComposingRegion(
+            TextTargetRange::utf8_bytes(6, 6),
+        ));
+        state.apply(TextInputEvent::CompositionUpdate(
+            CompositionState::new("に").with_replacement_range(TextTargetRange::utf8_bytes(6, 6)),
+        ));
+        assert_eq!(state.text, "hello に");
+        assert_eq!(state.composing_range, Some(TextRange::new(6, 9)));
+
+        state.apply(TextInputEvent::CompositionEnd);
+        assert_eq!(state.composing_range, None);
+    }
+}


### PR DESCRIPTION
Add a cross-platform text-input event model to `ui-events` via `TextInputEvent`, including committed text, composition state, and range metadata.

Add `EditCommandEvent` for semantic editing commands such as cursor movement, deletion, and selection operations.

Bridge the new event types from winit IME events and from web input/composition events.