### PR TITLE
apple-platforms: add foundation AppKit and UIKit adapters

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -8,3 +8,5 @@
 trivial-copy-size-limit = 16
 
 # END LINEBENDER LINT SET
+
+doc-valid-idents = ["AppKit", "UIKit", ".."]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ env:
   RUST_MIN_NO_STD_VER: "1.85"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p ui-events -p ui-events-web -p ui-events-winit -p ui-input-state -p ui-theme"
+  RUST_MIN_VER_PKGS: "-p ui-events -p ui-events-apple-common -p ui-events-appkit -p ui-events-uikit -p ui-events-web -p ui-events-winit -p ui-input-state -p ui-theme"
   # List of packages that will be checked for `no_std` builds.
   # This should be limited to packages that are intended for publishing.
-  RUST_NO_STD_PKGS: "-p ui-events -p ui-input-state -p ui-theme"
+  RUST_NO_STD_PKGS: "-p ui-events -p ui-events-apple-common -p ui-events-appkit -p ui-events-uikit -p ui-input-state -p ui-theme"
   # List of features that depend on the standard library and will be excluded from no_std checks.
   FEATURES_DEPENDING_ON_STD: "std,default"
 
@@ -108,6 +108,15 @@ jobs:
         # supports being placed at the top level, which we want to avoid cluttering.
         run: cargo rdme --workspace-project=ui-events --heading-base-level=0 --check
 
+      - name: cargo rdme (ui-events-apple-common)
+        run: cargo rdme --workspace-project=ui-events-apple-common --heading-base-level=0 --check
+
+      - name: cargo rdme (ui-events-appkit)
+        run: cargo rdme --workspace-project=ui-events-appkit --heading-base-level=0 --check
+
+      - name: cargo rdme (ui-events-uikit)
+        run: cargo rdme --workspace-project=ui-events-uikit --heading-base-level=0 --check
+
       - name: cargo rdme (ui-events-web)
         run: cargo rdme --workspace-project=ui-events-web --heading-base-level=0 --check
 
@@ -183,6 +192,30 @@ jobs:
 
       - name: cargo clippy (auxiliary)
         run: cargo hack clippy --workspace --locked --target wasm32-unknown-unknown --optional-deps --each-feature --ignore-unknown-features --features std --tests --benches --examples -- -D warnings
+
+  apple-adapter-targets:
+    name: apple adapter targets
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_STABLE_VER }}
+          targets: aarch64-apple-ios
+          components: clippy
+
+      - name: restore cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'merge_group' }}
+
+      - name: cargo check (iOS)
+        run: cargo check -p ui-events-uikit --locked --all-features --target aarch64-apple-ios
+
+      - name: cargo clippy (iOS)
+        run: cargo clippy -p ui-events-uikit --locked --all-features --target aarch64-apple-ios -- -D warnings
 
   test-stable:
     name: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -267,6 +267,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.4",
+]
+
+[[package]]
 name = "dlib"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +320,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "example-input-tracker"
+version = "0.2.0"
+dependencies = [
+ "ui-events",
 ]
 
 [[package]]
@@ -623,6 +640,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,11 +657,23 @@ dependencies = [
  "bitflags 2.10.0",
  "block2",
  "libc",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -646,9 +684,9 @@ checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -658,8 +696,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -670,8 +708,19 @@ checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -681,8 +730,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -693,9 +742,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-contacts",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -714,7 +763,18 @@ dependencies = [
  "block2",
  "dispatch",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -724,9 +784,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -737,8 +797,8 @@ checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -749,8 +809,8 @@ checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
@@ -760,8 +820,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -772,17 +832,29 @@ checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-link-presentation",
  "objc2-quartz-core",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -792,8 +864,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -804,9 +876,9 @@ checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.10.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1063,6 +1135,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_appkit"
+version = "0.3.0"
+dependencies = [
+ "example-input-tracker",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "ui-events",
+ "ui-events-appkit",
+]
+
+[[package]]
 name = "simple_web"
 version = "0.3.0"
 dependencies = [
@@ -1239,6 +1323,40 @@ dependencies = [
  "dpi",
  "keyboard-types",
  "kurbo",
+]
+
+[[package]]
+name = "ui-events-appkit"
+version = "0.3.0"
+dependencies = [
+ "dpi",
+ "libm",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "ui-events",
+ "ui-events-apple-common",
+]
+
+[[package]]
+name = "ui-events-apple-common"
+version = "0.3.0"
+dependencies = [
+ "dpi",
+ "ui-events",
+]
+
+[[package]]
+name = "ui-events-uikit"
+version = "0.3.0"
+dependencies = [
+ "dpi",
+ "libm",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit 0.3.2",
+ "ui-events",
+ "ui-events-apple-common",
 ]
 
 [[package]]
@@ -1692,10 +1810,10 @@ dependencies = [
  "libc",
  "memmap2",
  "ndk",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
- "objc2-ui-kit",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit 0.2.2",
  "orbclient",
  "percent-encoding",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,17 @@
 resolver = "2"
 members = [
     "ui-events",
+    "ui-events-apple-common",
+    "ui-events-appkit",
+    "ui-events-uikit",
     "ui-events-web",
     "ui-events-winit",
     "ui-input-state",
     "ui-theme",
     "examples/simple",
+    "examples/input_tracker",
     "examples/simple_web",
+    "examples/simple_appkit",
 ]
 
 [workspace.package]
@@ -74,6 +79,10 @@ clippy.wildcard_dependencies = "warn"
 
 [workspace.dependencies]
 dpi = { version = "0.1.2", default-features = false }
+example-input-tracker = { path = "examples/input_tracker" }
 ui-events = { version = "0.3.0", path = "ui-events", default-features = false }
+ui-events-apple-common = { version = "0.3.0", path = "ui-events-apple-common", default-features = false }
+ui-events-appkit = { version = "0.3.0", path = "ui-events-appkit" }
+ui-events-uikit = { version = "0.3.0", path = "ui-events-uikit" }
 ui-events-web = { version = "0.3.0", path = "ui-events-web" }
 web-time = "1.1.0"

--- a/examples/input_tracker/Cargo.toml
+++ b/examples/input_tracker/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "example-input-tracker"
+version = "0.2.0"
+edition = "2021"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[dependencies]
+ui-events = { workspace = true }
+
+[features]
+default = ["std"]
+std = []
+libm = ["ui-events/libm"]

--- a/examples/input_tracker/src/lib.rs
+++ b/examples/input_tracker/src/lib.rs
@@ -1,0 +1,205 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Shared input tracker for examples.
+//!
+//! Collects pointer and keyboard input into simple deques of points and a set of
+//! pressed keys, similar to the visualization used by `examples/simple_web`.
+//!
+//! This is intentionally tiny and UI-agnostic: it stores raw data (positions in
+//! physical pixels with a Y-down axis, and raw scroll deltas) for the examples
+//! to render however they like.
+
+#![expect(
+    missing_docs,
+    reason = "Small example helper: keep code compact without exhaustive docs"
+)]
+
+use std::collections::{BTreeSet, VecDeque};
+
+use ui_events::keyboard::KeyboardEvent;
+use ui_events::pointer::PointerEvent;
+
+/// Scroll sample captured from a pointer scroll event.
+#[derive(Clone, Debug)]
+pub struct ScrollSample {
+    pub x: f64,
+    pub y: f64,
+    pub delta: ui_events::ScrollDelta,
+    pub scale_factor: f64,
+}
+
+/// Position sample captured from pointer state.
+#[derive(Clone, Copy, Debug)]
+pub struct PointSample {
+    pub x: f64,
+    pub y: f64,
+    pub scale_factor: f64,
+}
+
+/// Tracks recent pointer points and pressed keys for examples.
+#[derive(Clone, Debug)]
+pub struct InputTracker {
+    pressed: BTreeSet<String>,
+    current: VecDeque<PointSample>,
+    coalesced: VecDeque<PointSample>,
+    predicted: VecDeque<PointSample>,
+    downs: VecDeque<PointSample>,
+    ups: VecDeque<PointSample>,
+    last_scroll: Option<ScrollSample>,
+}
+
+impl Default for InputTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InputTracker {
+    pub const CAP: usize = 4096;
+
+    pub fn new() -> Self {
+        Self {
+            pressed: BTreeSet::new(),
+            current: VecDeque::with_capacity(Self::CAP),
+            coalesced: VecDeque::with_capacity(Self::CAP),
+            predicted: VecDeque::with_capacity(Self::CAP),
+            downs: VecDeque::with_capacity(256),
+            ups: VecDeque::with_capacity(256),
+            last_scroll: None,
+        }
+    }
+
+    fn push_cap<T>(buf: &mut VecDeque<T>, val: T, cap: usize) {
+        if buf.len() >= cap {
+            buf.pop_front();
+        }
+        buf.push_back(val);
+    }
+
+    pub fn clear(&mut self) {
+        self.current.clear();
+        self.coalesced.clear();
+        self.predicted.clear();
+        self.downs.clear();
+        self.ups.clear();
+        self.last_scroll = None;
+        self.pressed.clear();
+    }
+
+    pub fn handle_pointer(&mut self, pe: &PointerEvent) {
+        use ui_events::pointer::PointerEvent as PE;
+        match pe {
+            PE::Move(update) => {
+                for s in &update.coalesced {
+                    Self::push_cap(
+                        &mut self.coalesced,
+                        PointSample {
+                            x: s.position.x,
+                            y: s.position.y,
+                            scale_factor: s.scale_factor,
+                        },
+                        Self::CAP,
+                    );
+                }
+                for s in &update.predicted {
+                    Self::push_cap(
+                        &mut self.predicted,
+                        PointSample {
+                            x: s.position.x,
+                            y: s.position.y,
+                            scale_factor: s.scale_factor,
+                        },
+                        Self::CAP,
+                    );
+                }
+                let s = &update.current;
+                Self::push_cap(
+                    &mut self.current,
+                    PointSample {
+                        x: s.position.x,
+                        y: s.position.y,
+                        scale_factor: s.scale_factor,
+                    },
+                    Self::CAP,
+                );
+            }
+            PE::Down(btn) => {
+                let s = &btn.state;
+                Self::push_cap(
+                    &mut self.downs,
+                    PointSample {
+                        x: s.position.x,
+                        y: s.position.y,
+                        scale_factor: s.scale_factor,
+                    },
+                    512,
+                );
+            }
+            PE::Up(btn) => {
+                let s = &btn.state;
+                Self::push_cap(
+                    &mut self.ups,
+                    PointSample {
+                        x: s.position.x,
+                        y: s.position.y,
+                        scale_factor: s.scale_factor,
+                    },
+                    512,
+                );
+            }
+            PE::Scroll(s) => {
+                self.last_scroll = Some(ScrollSample {
+                    x: s.state.position.x,
+                    y: s.state.position.y,
+                    delta: s.delta,
+                    scale_factor: s.state.scale_factor,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    pub fn handle_keyboard(&mut self, ke: &KeyboardEvent) {
+        // Prefer Code for recognizable names; fall back to key label.
+        let label = if !matches!(ke.code, ui_events::keyboard::Code::Unidentified) {
+            format!("{:?}", ke.code)
+        } else {
+            match &ke.key {
+                ui_events::keyboard::Key::Character(s) => s.clone(),
+                ui_events::keyboard::Key::Named(n) => format!("{:?}", n),
+            }
+        };
+        match ke.state {
+            ui_events::keyboard::KeyState::Down => {
+                self.pressed.insert(label);
+            }
+            ui_events::keyboard::KeyState::Up => {
+                self.pressed.remove(&label);
+            }
+        }
+    }
+
+    // Accessors for rendering
+    pub fn pressed_keys(&self) -> &BTreeSet<String> {
+        &self.pressed
+    }
+    pub fn current(&self) -> &VecDeque<PointSample> {
+        &self.current
+    }
+    pub fn coalesced(&self) -> &VecDeque<PointSample> {
+        &self.coalesced
+    }
+    pub fn predicted(&self) -> &VecDeque<PointSample> {
+        &self.predicted
+    }
+    pub fn downs(&self) -> &VecDeque<PointSample> {
+        &self.downs
+    }
+    pub fn ups(&self) -> &VecDeque<PointSample> {
+        &self.ups
+    }
+    pub fn last_scroll(&self) -> Option<&ScrollSample> {
+        self.last_scroll.as_ref()
+    }
+}

--- a/examples/simple_appkit/Cargo.toml
+++ b/examples/simple_appkit/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "simple_appkit"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+ui-events = { workspace = true }
+ui-events-appkit = { workspace = true }
+example-input-tracker = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = { version = "0.6.2", default-features = false, features = ["std"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "NSAutoreleasePool",
+    "NSDate",
+    "NSValue",
+    "NSString",
+    "NSGeometry",
+] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
+    "NSApplication",
+    "NSResponder",
+    "NSEvent",
+    "NSWindow",
+    "NSView",
+    "NSGraphics",
+    "NSBezierPath",
+    "NSColor",
+    "NSFont",
+    "NSTextField",
+    "NSButton",
+    "NSRunningApplication",
+    "objc2-core-foundation",
+    "NSStringDrawing",
+] }
+
+[lints]
+workspace = true

--- a/examples/simple_appkit/src/main.rs
+++ b/examples/simple_appkit/src/main.rs
@@ -1,0 +1,320 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Minimal macOS AppKit example that converts `NSEvent` into `ui-events` via
+//! `ui-events-appkit` and draws a simple visualization in a custom `NSView`.
+
+#![allow(unsafe_code, reason = "We access platform libraries using ffi.")]
+// Keep example code compact without exhaustive docs.
+
+#[cfg(target_os = "macos")]
+mod appkit_example {
+    use std::cell::RefCell;
+
+    use objc2::MainThreadMarker;
+    use objc2::rc::{Retained, autoreleasepool};
+    use objc2::{DefinedClass, MainThreadOnly, define_class, msg_send};
+    use objc2_app_kit::{
+        NSApplication, NSApplicationActivationPolicy, NSBezierPath, NSColor, NSEvent, NSResponder,
+        NSStringDrawing, NSView, NSWindow, NSWindowStyleMask,
+    };
+    use objc2_foundation::{NSPoint, NSRect, NSSize, NSString};
+    use ui_events::keyboard::KeyboardEvent;
+    use ui_events::pointer::PointerEvent as UiPointerEvent;
+
+    #[derive(Default, Debug)]
+    struct VizState {
+        tracker: RefCell<example_input_tracker::InputTracker>,
+    }
+
+    define_class!(
+        #[unsafe(super = NSView)]
+        #[thread_kind = objc2::MainThreadOnly]
+        #[ivars = VizState]
+        struct VizView;
+
+        impl VizView {
+            #[unsafe(method(acceptsFirstResponder))]
+            fn accepts_first_responder(&self) -> bool { false }
+            #[unsafe(method(isFlipped))]
+            fn is_flipped(&self) -> bool { true }
+
+            #[unsafe(method(drawRect:))]
+            fn draw_rect(&self, _rect: NSRect) {
+                // Background fill
+                NSColor::blackColor().setFill();
+                let bounds = self.bounds();
+                NSBezierPath::fillRect(bounds);
+
+                // Draw like simple_web: dots only (no polyline)
+                let samples = self.ivars().tracker.borrow();
+
+                // Coalesced points (light blue)
+                for s in samples.coalesced().iter().copied() {
+                    let p = point_sample_to_view(self, s);
+                    let dot = NSBezierPath::bezierPathWithOvalInRect(NSRect::new(
+                        NSPoint::new(p.x - 2.0, p.y - 2.0),
+                        NSSize::new(4.0, 4.0),
+                    ));
+                    NSColor::colorWithSRGBRed_green_blue_alpha(64.0/255.0, 160.0/255.0, 1.0, 0.3).setFill();
+                    dot.fill();
+                }
+                // Predicted points (orange)
+                for s in samples.predicted().iter().copied() {
+                    let p = point_sample_to_view(self, s);
+                    let dot = NSBezierPath::bezierPathWithOvalInRect(NSRect::new(
+                        NSPoint::new(p.x - 3.0, p.y - 3.0),
+                        NSSize::new(6.0, 6.0),
+                    ));
+                    NSColor::colorWithSRGBRed_green_blue_alpha(1.0, 160.0/255.0, 0.0, 0.45).setFill();
+                    dot.fill();
+                }
+                // Current trail (solid blue dots with stroke)
+                for s in samples.current().iter().copied() {
+                    let p = point_sample_to_view(self, s);
+                    let dot = NSBezierPath::bezierPathWithOvalInRect(NSRect::new(
+                        NSPoint::new(p.x - 3.0, p.y - 3.0),
+                        NSSize::new(6.0, 6.0),
+                    ));
+                    let fill = NSColor::colorWithSRGBRed_green_blue_alpha(64.0/255.0, 160.0/255.0, 1.0, 0.9);
+                    fill.setFill();
+                    dot.fill();
+                    fill.setStroke();
+                    dot.setLineWidth(1.0);
+                    dot.stroke();
+                }
+
+                // Mark downs/ups
+                // Down rings (green) and up rings (red), with fill + stroke like web demo
+                for s in samples.downs().iter().copied() {
+                    let p = point_sample_to_view(self, s);
+                    let rect = NSRect::new(NSPoint::new(p.x - 9.0, p.y - 9.0), NSSize::new(18.0, 18.0));
+                    let dot = NSBezierPath::bezierPathWithOvalInRect(rect);
+                    NSColor::colorWithSRGBRed_green_blue_alpha(0.0, 200.0/255.0, 120.0/255.0, 0.25).setFill();
+                    dot.fill();
+                    NSColor::colorWithSRGBRed_green_blue_alpha(0.0, 200.0/255.0, 120.0/255.0, 0.9).setStroke();
+                    dot.setLineWidth(1.0);
+                    dot.stroke();
+                }
+                for s in samples.ups().iter().copied() {
+                    let p = point_sample_to_view(self, s);
+                    let rect = NSRect::new(NSPoint::new(p.x - 7.0, p.y - 7.0), NSSize::new(14.0, 14.0));
+                    let dot = NSBezierPath::bezierPathWithOvalInRect(rect);
+                    NSColor::colorWithSRGBRed_green_blue_alpha(1.0, 80.0/255.0, 80.0/255.0, 0.25).setFill();
+                    dot.fill();
+                    NSColor::colorWithSRGBRed_green_blue_alpha(1.0, 80.0/255.0, 80.0/255.0, 0.9).setStroke();
+                    dot.setLineWidth(1.0);
+                    dot.stroke();
+                }
+
+                // Scroll indicator vector
+                if let Some(scroll) = samples.last_scroll() {
+                    let p = logical_point(self, scroll.x / scroll.scale_factor, scroll.y / scroll.scale_factor);
+                    let (dx, dy) = match scroll.delta {
+                        ui_events::ScrollDelta::PixelDelta(ph) => (
+                            ph.x / scroll.scale_factor,
+                            -(ph.y / scroll.scale_factor),
+                        ),
+                        ui_events::ScrollDelta::LineDelta(x, y) => (x as f64 * 12.0, -(y as f64) * 12.0),
+                        ui_events::ScrollDelta::PageDelta(x, y) => (x as f64 * 80.0, -(y as f64) * 80.0),
+                    };
+                    let vec = NSBezierPath::bezierPath();
+                    NSColor::systemBlueColor().setStroke();
+                    vec.setLineWidth(1.5);
+                    vec.moveToPoint(p);
+                    vec.lineToPoint(NSPoint::new(p.x + dx, p.y + dy));
+                    vec.stroke();
+                }
+
+                // HUD background and text
+                let hud = hud_clear_rect(self);
+                let bg = NSBezierPath::bezierPathWithRoundedRect_xRadius_yRadius(hud, 6.0, 6.0);
+                // Light background for contrast with default (black) text
+                NSColor::colorWithSRGBRed_green_blue_alpha(0.95, 0.95, 0.95, 0.85).setFill();
+                bg.fill();
+                NSColor::blackColor().setStroke();
+                bg.stroke();
+
+                let keys = {
+                    let set = samples.pressed_keys();
+                    if set.is_empty() { String::from("(none)") } else { set.iter().cloned().collect::<Vec<_>>().join(", ") }
+                };
+                let scroll_txt = if let Some(scroll) = samples.last_scroll() {
+                    let (dx, dy) = match scroll.delta {
+                        ui_events::ScrollDelta::PixelDelta(ph) => (
+                            ph.x / scroll.scale_factor,
+                            -(ph.y / scroll.scale_factor),
+                        ),
+                        ui_events::ScrollDelta::LineDelta(x, y) => (x as f64 * 12.0, -(y as f64) * 12.0),
+                        ui_events::ScrollDelta::PageDelta(x, y) => (x as f64 * 80.0, -(y as f64) * 80.0),
+                    };
+                    format!("dx={:.1} dy={:.1}", dx, dy)
+                } else { String::from("dx=0 dy=0") };
+                let text = NSString::from_str(&format!("Keys: {}    Scroll: {}    [Clear]", keys, scroll_txt));
+                unsafe { text.drawAtPoint_withAttributes(NSPoint::new(hud.origin.x + 8.0, hud.origin.y + 5.0), None) };
+            }
+        }
+    );
+
+    struct VizInputHost {
+        view: Retained<VizView>,
+    }
+
+    impl ui_events_appkit::AppKitInputResponderHost for VizInputHost {
+        fn handle_keyboard_event(&self, event: KeyboardEvent) {
+            handle_keyboard(&self.view, event);
+        }
+
+        fn handle_pointer_event(&self, event: UiPointerEvent) {
+            if should_clear_hud_from_pointer_event(&self.view, &event) {
+                self.view.ivars().tracker.borrow_mut().clear();
+                self.view.setNeedsDisplay(true);
+                return;
+            }
+            handle_pointer(&self.view, event);
+        }
+
+        fn pointer_position(&self, event: &NSEvent) -> (f64, f64) {
+            let point = self
+                .view
+                .convertPoint_fromView(event.locationInWindow(), None);
+            (point.x, point.y)
+        }
+
+        fn pointer_scale_factor(&self) -> f64 {
+            self.view
+                .window()
+                .map(|window| window.backingScaleFactor())
+                .unwrap_or(1.0)
+        }
+    }
+
+    // Minimal NSApplication delegate that terminates after last window closes.
+    define_class!(
+        #[unsafe(super = NSResponder)]
+        #[thread_kind = objc2::MainThreadOnly]
+        struct AppDelegate;
+
+        impl AppDelegate {
+            #[unsafe(method(applicationShouldTerminateAfterLastWindowClosed:))]
+            fn application_should_terminate_after_last_window_closed(
+                &self,
+                _app: &NSApplication,
+            ) -> bool {
+                true
+            }
+        }
+    );
+
+    fn hud_clear_rect(view: &VizView) -> NSRect {
+        let w = view.bounds().size.width;
+        let width = (w * 0.7).min(700.0);
+        NSRect::new(NSPoint::new(8.0, 8.0), NSSize::new(width, 24.0))
+    }
+
+    fn point_sample_to_view(view: &VizView, s: example_input_tracker::PointSample) -> NSPoint {
+        logical_point(view, s.x / s.scale_factor, s.y / s.scale_factor)
+    }
+
+    fn logical_point(_view: &VizView, x: f64, y: f64) -> NSPoint {
+        NSPoint::new(x, y)
+    }
+
+    fn should_clear_hud_from_pointer_event(view: &VizView, event: &UiPointerEvent) -> bool {
+        let UiPointerEvent::Down(event) = event else {
+            return false;
+        };
+        let point = logical_point(
+            view,
+            event.state.position.x / event.state.scale_factor,
+            event.state.position.y / event.state.scale_factor,
+        );
+        let clear = hud_clear_rect(view);
+        point.x >= clear.origin.x
+            && point.x <= clear.origin.x + clear.size.width
+            && point.y >= clear.origin.y
+            && point.y <= clear.origin.y + clear.size.height
+    }
+
+    fn handle_pointer(view: &VizView, ev: UiPointerEvent) {
+        view.ivars().tracker.borrow_mut().handle_pointer(&ev);
+        view.setNeedsDisplay(true);
+    }
+
+    fn handle_keyboard(view: &VizView, ev: KeyboardEvent) {
+        view.ivars().tracker.borrow_mut().handle_keyboard(&ev);
+        view.setNeedsDisplay(true);
+    }
+
+    pub(crate) fn run() {
+        autoreleasepool(|_| {
+            let mtm = MainThreadMarker::new().expect("must run on main thread");
+            let app = NSApplication::sharedApplication(mtm);
+            app.setActivationPolicy(NSApplicationActivationPolicy::Regular);
+            // Set up delegate to terminate after last window is closed.
+            let delegate: Retained<AppDelegate> = {
+                let this = AppDelegate::alloc(mtm);
+                unsafe { msg_send![this, init] }
+            };
+            let _: () = unsafe { msg_send![&*app, setDelegate: &*delegate] };
+
+            // Create a window and our custom view
+            let content_rect = NSRect::new(NSPoint::new(100., 100.), NSSize::new(800., 600.));
+            let style = NSWindowStyleMask::Titled
+                | NSWindowStyleMask::Closable
+                | NSWindowStyleMask::Resizable
+                | NSWindowStyleMask::Miniaturizable;
+            let window: Retained<NSWindow> = unsafe {
+                msg_send![NSWindow::alloc(mtm),
+                    initWithContentRect: content_rect,
+                    styleMask: style,
+                    backing: objc2_app_kit::NSBackingStoreType::Buffered,
+                    defer: false]
+            };
+            // Required when creating NSWindow outside a controller.
+            unsafe { window.setReleasedWhenClosed(false) };
+            window.center();
+            window.setTitle(&NSString::from_str("ui-events AppKit example"));
+
+            let view: Retained<VizView> = {
+                let this = VizView::alloc(mtm).set_ivars(VizState::default());
+                unsafe { msg_send![super(this), initWithFrame: content_rect] }
+            };
+            window.setContentView(Some(&view));
+            let input_responder = ui_events_appkit::AppKitInputResponder::new(
+                mtm,
+                Box::new(VizInputHost {
+                    view: Retained::clone(&view),
+                }),
+            );
+            // SAFETY: `view` is retained by `window`, `input_responder` is
+            // retained in this stack frame for the AppKit run loop lifetime,
+            // and the previous next responder is owned by AppKit.
+            unsafe {
+                let following_responder = view.nextResponder();
+                input_responder.set_following_responder(following_responder.as_deref());
+                view.setNextResponder(Some(input_responder.as_ref()));
+            }
+            window.setAcceptsMouseMovedEvents(true);
+            let _ = window.makeFirstResponder(Some(input_responder.as_ref()));
+            window.makeKeyAndOrderFront(None);
+            app.activate();
+
+            // No external HUD widgets; HUD rendered in drawRect and clear handled via click detection.
+
+            // Enter the native AppKit run loop; the app delegate will terminate
+            // the app automatically after the last window closes.
+            app.run();
+        });
+    }
+}
+
+fn main() {
+    #[cfg(target_os = "macos")]
+    appkit_example::run();
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        eprintln!("This example is macOS-only.");
+    }
+}

--- a/ui-events-appkit/CHANGELOG.md
+++ b/ui-events-appkit/CHANGELOG.md
@@ -1,0 +1,24 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+UI Events AppKit has not yet been published.
+
+## [Unreleased]
+
+This release has an [MSRV][] of 1.85.
+
+### Added
+
+- AppKit pointer and keyboard adapter helpers.
+- `AppKitInputResponder`, a reusable `NSResponder` for pointer and keyboard input.
+
+[Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/ui-events-appkit/Cargo.toml
+++ b/ui-events-appkit/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "ui-events-appkit"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Bridges AppKit (macOS) events into ui-events via objc2"
+keywords = ["apple", "macos", "appkit", "objc2", "input"]
+categories = ["gui"]
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "aarch64-apple-darwin"
+targets = []
+
+[features]
+default = ["std"]
+libm = ["dep:libm"]
+std = ["ui-events/std", "ui-events-apple-common/std", "dpi/std"]
+
+[dependencies]
+ui-events.workspace = true
+ui-events-apple-common.workspace = true
+dpi.workspace = true
+libm = { version = "0.2.15", optional = true, default-features = false }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = { version = "0.6.2", default-features = false, features = ["std"] }
+objc2-app-kit = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "NSEvent",
+    "NSResponder",
+    "objc2-core-foundation",
+] }
+
+[lints]
+workspace = true

--- a/ui-events-appkit/LICENSE-APACHE
+++ b/ui-events-appkit/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/ui-events-appkit/LICENSE-MIT
+++ b/ui-events-appkit/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ui-events-appkit/README.md
+++ b/ui-events-appkit/README.md
@@ -1,0 +1,169 @@
+<div align="center">
+
+# UI Events AppKit Adapter
+
+A library for bridging AppKit events into the `ui-events` model.
+
+[![Linebender Zulip, #general channel](https://img.shields.io/badge/Linebender-%23general-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/147921-general)
+[![dependency status](https://deps.rs/repo/github/endoli/ui-events/status.svg)](https://deps.rs/repo/github/endoli/ui-events)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+[![Build status](https://github.com/endoli/ui-events/workflows/CI/badge.svg)](https://github.com/endoli/ui-events/actions)
+[![Crates.io](https://img.shields.io/crates/v/ui-events-appkit.svg)](https://crates.io/crates/ui-events-appkit)
+[![Docs](https://docs.rs/ui-events-appkit/badge.svg)](https://docs.rs/ui-events-appkit)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=ui-events-appkit --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
+[`ui-events`]: https://docs.rs/ui-events/
+<!-- cargo-rdme start -->
+
+AppKit (macOS) adapter using `objc2`.
+
+This crate provides lightweight helpers to convert AppKit events into
+[`ui-events`] types, mirroring the style of the `ui-events-web` and
+`ui-events-winit` adapters.
+
+It does not provide an `NSView` implementation for you. Instead, your
+AppKit view or responder should call these helpers from the corresponding
+AppKit callbacks.
+
+Currently supported:
+
+- Pointer (mouse/pen) down/up/move/enter/leave/scroll
+- Trackpad gestures: magnify (pinch) and rotate
+- Keyboard down/up
+- `AppKitInputResponder`, a reusable `NSResponder` for pointer, scroll,
+  gesture, tablet, and keyboard input
+
+`AppKitInputResponder` intentionally does not implement text input, IME, or
+edit-command protocols.
+
+## Feature Policy
+
+- `std` is enabled by default.
+- `libm` is required for `no_std` builds because tablet tilt orientation uses
+  trigonometry.
+- With `default-features = false`, the crate remains `no_std` with `alloc`
+  and still compiles on non-macOS targets because the `objc2` dependencies
+  are behind `target_os = "macos"`.
+- On macOS targets, the `objc2*` crates are compiled with their `std` feature
+  enabled to support Objective-C runtime integration.
+- Defaults avoid pulling in unnecessary APIs by disabling default features
+  for `objc2*` crates and enabling only the AppKit symbols this crate uses.
+
+## Pointer Notes
+
+- Pointer positions come from `NSEvent::locationInWindow`, scaled from
+  points into physical pixels but not converted into a specific `NSView`.
+  `pointer_event_from_nsevent_at_position` accepts a caller-provided
+  coordinate, and `AppKitInputResponderHost` requires the host to provide
+  the position in its own coordinate space.
+- Event timestamps use AppKit's monotonic seconds-since-boot timebase, not
+  Unix epoch time.
+- Mouse button down/up click counts use AppKit's `clickCount` directly.
+  Other pointer event kinds, including scroll events, use `0` without
+  querying click metadata from AppKit.
+- Mouse events may query AppKit tablet metadata when AppKit reports tablet
+  mouse-event subtypes. Scroll events do not query tablet metadata.
+- Tablet tilt uses AppKit's `NSEvent::tilt` fractions, where `0.0` is
+  perpendicular and `1.0` is parallel to the surface along that axis.
+
+## Scroll Deltas
+
+- Scroll deltas preserve AppKit's `scrollingDeltaX/Y` sign, which already
+  reflects the user's natural-scrolling preference and matches the macOS
+  path used by `winit`.
+- When `hasPreciseScrollingDeltas` is true, deltas map to
+  [`ScrollDelta::PixelDelta`]. Otherwise, they map to
+  [`ScrollDelta::LineDelta`].
+
+## Gestures
+
+- Magnify gesture events map to [`PointerGesture::Pinch`](ui_events::pointer::PointerGesture::Pinch)
+  using AppKit's per-event `magnification` delta.
+- Rotate gesture events map to
+  [`PointerGesture::Rotate`](ui_events::pointer::PointerGesture::Rotate) in
+  clockwise radians.
+
+## Tablet Events
+
+- `NSEventType::TabletPoint` maps to [`PointerType::Pen`] with pressure,
+  tangential pressure, and orientation derived from AppKit tilt fractions.
+- `NSEventType::TabletProximity` maps to `PointerEvent::Enter` or
+  `PointerEvent::Leave` based on `isEnteringProximity`.
+
+## Keyboard Notes
+
+- `flagsChanged` uses aggregate modifier flags. Releasing one side of a
+  modifier while the other side remains held may still report the key as
+  down until this adapter grows device-dependent left/right modifier masks.
+
+## High-Level Helpers
+
+- `AppKitInputResponder`
+- `pointer_event_from_nsevent`
+- `pointer_event_from_nsevent_at_position`
+- `keyboard_event_from_nsevent`
+
+If you prefer, low-level mappers in [`mapping`] let you build events from
+raw values (e.g. coordinates, button number, modifier booleans) without
+pulling in AppKit types in your own code.
+
+[`PointerType::Pen`]: ui_events::pointer::PointerType::Pen
+[`ScrollDelta::LineDelta`]: ui_events::ScrollDelta::LineDelta
+[`ScrollDelta::PixelDelta`]: ui_events::ScrollDelta::PixelDelta
+[`ui-events`]: https://docs.rs/ui-events/
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This version of UI Events AppKit has been verified to compile with **Rust 1.85** and later.
+
+Future versions of UI Events AppKit might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some UI Events AppKit dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
+## Community
+
+[![Linebender Zulip](https://img.shields.io/badge/Xi%20Zulip-%23general-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/147921-general)
+
+Discussion of UI Events AppKit development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#general channel](https://xi.zulipchat.com/#narrow/channel/147921-general).
+All public content can be read without logging in.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ./AUTHORS

--- a/ui-events-appkit/src/appkit.rs
+++ b/ui-events-appkit/src/appkit.rs
@@ -1,0 +1,858 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! `AppKit` (macOS) shims that extract fields from `objc2_app_kit::NSEvent` and
+//! forward to platform-neutral mappers.
+
+// cfg is handled at the module declaration in lib.rs
+
+use alloc::string::ToString;
+use objc2_app_kit::{
+    NSEvent, NSEventModifierFlags, NSEventSubtype, NSEventType, NSPointingDeviceType,
+};
+
+use crate::mapping as map;
+use ui_events::keyboard::{Code, Key, KeyState, KeyboardEvent, Location, NamedKey};
+use ui_events::pointer::{
+    PointerButtonEvent, PointerEvent, PointerGesture, PointerGestureEvent, PointerScrollEvent,
+    PointerType, PointerUpdate,
+};
+
+mod keycodes;
+use keycodes as vk;
+
+fn mods_has(flags: NSEventModifierFlags, bit: NSEventModifierFlags) -> bool {
+    flags.contains(bit)
+}
+
+fn pointer_type_from_pointing_device(pointing_device: NSPointingDeviceType) -> PointerType {
+    match pointing_device {
+        NSPointingDeviceType::Pen | NSPointingDeviceType::Eraser => PointerType::Pen,
+        _ => PointerType::Mouse,
+    }
+}
+
+fn pen_pointer_info_for_mouse_event(
+    subtype: NSEventSubtype,
+    pointing_device: NSPointingDeviceType,
+    unique_id: u64,
+    device_id: u64,
+) -> Option<ui_events::pointer::PointerInfo> {
+    (subtype == NSEventSubtype::TabletPoint
+        && matches!(
+            pointing_device,
+            NSPointingDeviceType::Pen | NSPointingDeviceType::Eraser
+        ))
+    .then(|| {
+        map::pointer_info_from_platform_ids(PointerType::Pen, Some(unique_id), Some(device_id))
+    })
+}
+
+fn pen_buttons_mask(pointing_device: NSPointingDeviceType, buttons_mask: u64) -> u64 {
+    if pointing_device == NSPointingDeviceType::Eraser {
+        buttons_mask | (1_u64 << 5)
+    } else {
+        buttons_mask
+    }
+}
+
+fn pen_transition_button(
+    pointing_device: NSPointingDeviceType,
+    button_number: i64,
+) -> Option<ui_events::pointer::PointerButton> {
+    if pointing_device == NSPointingDeviceType::Eraser {
+        Some(ui_events::pointer::PointerButton::PenEraser)
+    } else {
+        map::try_from_button_index(button_number)
+    }
+}
+
+fn button_mask_bit(button_number: i64) -> Option<u64> {
+    (0..32)
+        .contains(&button_number)
+        .then(|| 1_u64 << button_number)
+}
+
+fn mouse_buttons_after_down(current_mask: u64, button_number: i64) -> u64 {
+    button_mask_bit(button_number).map_or(current_mask, |bit| current_mask | bit)
+}
+
+fn mouse_buttons_after_up(current_mask: u64, button_number: i64) -> u64 {
+    button_mask_bit(button_number).map_or(current_mask, |bit| current_mask & !bit)
+}
+
+fn click_count_for_mouse_button_event(
+    event_type: NSEventType,
+    read_click_count: impl FnOnce() -> i64,
+) -> i64 {
+    match event_type {
+        NSEventType::LeftMouseDown
+        | NSEventType::RightMouseDown
+        | NSEventType::OtherMouseDown
+        | NSEventType::LeftMouseUp
+        | NSEventType::RightMouseUp
+        | NSEventType::OtherMouseUp => read_click_count(),
+        _ => 0,
+    }
+}
+
+fn pen_pointer_info_for_mouse_nsevent(
+    event_type: NSEventType,
+    read_pen_pointer_info: impl FnOnce() -> Option<ui_events::pointer::PointerInfo>,
+) -> Option<ui_events::pointer::PointerInfo> {
+    match event_type {
+        NSEventType::LeftMouseDown
+        | NSEventType::RightMouseDown
+        | NSEventType::OtherMouseDown
+        | NSEventType::LeftMouseUp
+        | NSEventType::RightMouseUp
+        | NSEventType::OtherMouseUp
+        | NSEventType::MouseMoved
+        | NSEventType::LeftMouseDragged
+        | NSEventType::RightMouseDragged
+        | NSEventType::OtherMouseDragged => read_pen_pointer_info(),
+        _ => None,
+    }
+}
+
+/// Convert an AppKit keyboard `NSEvent` into a `ui-events` [`KeyboardEvent`].
+pub fn keyboard_event_from_nsevent(e: &NSEvent) -> Option<KeyboardEvent> {
+    let ty = e.r#type();
+    if ty == NSEventType::FlagsChanged {
+        // Modifier toggle treated as a KeyDown/KeyUp on the modifier.
+        let (code, named, location, flag) = map_modifier_toggle(e.keyCode())?;
+        let flags = e.modifierFlags();
+        // Known limitation: `modifierFlags` exposes aggregate modifier state.
+        // If both left and right variants of the same modifier are held,
+        // releasing one side still leaves the aggregate bit set and is reported
+        // as down. Distinguishing that requires device-dependent masks.
+        let is_down = flags.contains(flag);
+        return Some(ui_events::keyboard::KeyboardEvent {
+            state: if is_down {
+                KeyState::Down
+            } else {
+                KeyState::Up
+            },
+            key: Key::Named(named),
+            code,
+            location,
+            modifiers: map::modifiers_from_bools(
+                mods_has(flags, NSEventModifierFlags::Control),
+                mods_has(flags, NSEventModifierFlags::Option),
+                mods_has(flags, NSEventModifierFlags::Shift),
+                mods_has(flags, NSEventModifierFlags::Command),
+            ),
+            is_composing: false,
+            repeat: false,
+        });
+    }
+
+    let is_down = match ty {
+        NSEventType::KeyDown => true,
+        NSEventType::KeyUp => false,
+        _ => return None,
+    };
+    let flags = e.modifierFlags();
+
+    let ctrl = mods_has(flags, NSEventModifierFlags::Control);
+    let alt = mods_has(flags, NSEventModifierFlags::Option);
+    let shift = mods_has(flags, NSEventModifierFlags::Shift);
+    let meta = mods_has(flags, NSEventModifierFlags::Command);
+
+    let (code, named, location) = map_virtual_keycode_to_code_named_location(e.keyCode());
+    let characters = e.characters().map(|chars| chars.to_string());
+    let unmodified_characters = e
+        .charactersIgnoringModifiers()
+        .map(|chars| chars.to_string());
+    let key_value = key_from_appkit_strings(
+        named,
+        characters.as_deref(),
+        unmodified_characters.as_deref(),
+    );
+
+    Some(KeyboardEvent {
+        state: if is_down {
+            KeyState::Down
+        } else {
+            KeyState::Up
+        },
+        key: key_value,
+        code,
+        location,
+        modifiers: map::modifiers_from_bools(ctrl, alt, shift, meta),
+        is_composing: false,
+        repeat: e.isARepeat(),
+    })
+}
+
+/// Convert an AppKit pointer-related `NSEvent` into a `ui-events` [`PointerEvent`].
+///
+/// Positions come from [`NSEvent::locationInWindow`], so they are in AppKit
+/// window coordinates with AppKit's origin convention. This helper only scales
+/// point values into physical pixels; hosts that need view-local or flipped
+/// coordinates should call [`pointer_event_from_nsevent_at_position`] instead.
+///
+/// Event timestamps are AppKit's monotonic seconds-since-boot timebase, not
+/// Unix epoch time.
+///
+/// Mouse button down/up click counts use AppKit's `clickCount` directly.
+/// Other pointer event kinds, including scroll events, use a count of `0`
+/// without querying click metadata from AppKit.
+///
+/// Mouse events may query AppKit tablet metadata when AppKit reports tablet
+/// mouse-event subtypes. Scroll events do not query tablet metadata.
+///
+/// Scroll deltas preserve AppKit's `scrollingDeltaX/Y` sign. AppKit already
+/// applies the user's natural-scrolling preference to those values, and this
+/// matches the macOS path used by `winit`.
+///
+/// Magnify gesture events map to [`PointerGesture::Pinch`] using AppKit's
+/// per-event `magnification` delta.
+pub fn pointer_event_from_nsevent(e: &NSEvent, scale_factor: f64) -> Option<PointerEvent> {
+    let p = e.locationInWindow();
+    pointer_event_from_nsevent_at_position(e, scale_factor, p.x, p.y)
+}
+
+/// Convert an AppKit pointer-related `NSEvent` at a caller-provided position.
+///
+/// `x_points` and `y_points` are logical AppKit points in the coordinate space
+/// chosen by the caller. The values are scaled into physical pixels by
+/// `scale_factor`. Use this when an `NSEvent` has already been converted from
+/// window coordinates into a specific `NSView` or other host coordinate space.
+///
+/// Event timestamps are AppKit's monotonic seconds-since-boot timebase, not
+/// Unix epoch time.
+///
+/// Mouse button down/up click counts use AppKit's `clickCount` directly.
+/// Other pointer event kinds, including scroll events, use a count of `0`
+/// without querying click metadata from AppKit.
+///
+/// Mouse events may query AppKit tablet metadata when AppKit reports tablet
+/// mouse-event subtypes. Scroll events do not query tablet metadata.
+///
+/// Scroll deltas preserve AppKit's `scrollingDeltaX/Y` sign. AppKit already
+/// applies the user's natural-scrolling preference to those values, and this
+/// matches the macOS path used by `winit`.
+///
+/// Magnify gesture events map to [`PointerGesture::Pinch`] using AppKit's
+/// per-event `magnification` delta.
+pub fn pointer_event_from_nsevent_at_position(
+    e: &NSEvent,
+    scale_factor: f64,
+    x_points: f64,
+    y_points: f64,
+) -> Option<PointerEvent> {
+    let ty = e.r#type();
+
+    let flags = e.modifierFlags();
+
+    let ctrl = mods_has(flags, NSEventModifierFlags::Control);
+    let alt = mods_has(flags, NSEventModifierFlags::Option);
+    let shift = mods_has(flags, NSEventModifierFlags::Shift);
+    let meta = mods_has(flags, NSEventModifierFlags::Command);
+
+    let timestamp_secs = e.timestamp();
+    let click_count = click_count_for_mouse_button_event(ty, || e.clickCount() as i64);
+
+    let pen_pointer_info = pen_pointer_info_for_mouse_nsevent(ty, || {
+        pen_pointer_info_for_mouse_event(
+            e.subtype(),
+            e.pointingDeviceType(),
+            e.uniqueID(),
+            e.deviceID() as u64,
+        )
+    });
+
+    let state = |buttons_mask: u64, pressure: Option<f64>, tangential_pressure: Option<f64>| {
+        map::pointer_state_from_raw(
+            x_points,
+            y_points,
+            scale_factor,
+            buttons_mask,
+            ctrl,
+            alt,
+            shift,
+            meta,
+            pressure,
+            tangential_pressure,
+            None,
+            None,
+            timestamp_secs,
+            click_count,
+        )
+    };
+
+    Some(match ty {
+        NSEventType::LeftMouseDown | NSEventType::RightMouseDown | NSEventType::OtherMouseDown => {
+            if let Some(pointer) = pen_pointer_info {
+                let pointing_device = e.pointingDeviceType();
+                let mut state = state(
+                    pen_buttons_mask(pointing_device, e.buttonMask().0 as u64),
+                    Some(e.pressure() as f64),
+                    Some(e.tangentialPressure() as f64),
+                );
+                let tilt = e.tilt();
+                state.orientation = map::orientation_from_tilt_fraction(tilt.x, tilt.y);
+                PointerEvent::Down(ui_events::pointer::PointerButtonEvent {
+                    button: pen_transition_button(pointing_device, e.buttonNumber() as i64),
+                    pointer,
+                    state,
+                })
+            } else {
+                // `pressedMouseButtons` is AppKit's current global button
+                // state for this callback. Force the transition button into
+                // the state so this remains correct if AppKit's global mask is
+                // observed before it includes the down transition.
+                let buttons_mask = mouse_buttons_after_down(
+                    NSEvent::pressedMouseButtons() as u64,
+                    e.buttonNumber() as i64,
+                );
+                PointerEvent::Down(PointerButtonEvent {
+                    button: map::try_from_button_index(e.buttonNumber() as i64),
+                    pointer: map::pointer_info_primary_for_type(PointerType::Mouse),
+                    state: state(buttons_mask, None, None),
+                })
+            }
+        }
+        NSEventType::LeftMouseUp | NSEventType::RightMouseUp | NSEventType::OtherMouseUp => {
+            if let Some(pointer) = pen_pointer_info {
+                let pointing_device = e.pointingDeviceType();
+                let mut state = state(
+                    pen_buttons_mask(pointing_device, e.buttonMask().0 as u64),
+                    Some(e.pressure() as f64),
+                    Some(e.tangentialPressure() as f64),
+                );
+                let tilt = e.tilt();
+                state.orientation = map::orientation_from_tilt_fraction(tilt.x, tilt.y);
+                PointerEvent::Up(ui_events::pointer::PointerButtonEvent {
+                    button: pen_transition_button(pointing_device, e.buttonNumber() as i64),
+                    pointer,
+                    state,
+                })
+            } else {
+                // `pressedMouseButtons` is AppKit's current global button
+                // state for this callback. Force the transition button out of
+                // the state so this remains correct if AppKit's global mask is
+                // observed before it drops the up transition.
+                let buttons_mask = mouse_buttons_after_up(
+                    NSEvent::pressedMouseButtons() as u64,
+                    e.buttonNumber() as i64,
+                );
+                PointerEvent::Up(PointerButtonEvent {
+                    button: map::try_from_button_index(e.buttonNumber() as i64),
+                    pointer: map::pointer_info_primary_for_type(PointerType::Mouse),
+                    state: state(buttons_mask, None, None),
+                })
+            }
+        }
+        NSEventType::MouseMoved
+        | NSEventType::LeftMouseDragged
+        | NSEventType::RightMouseDragged
+        | NSEventType::OtherMouseDragged => {
+            // Pen tablet motion is emitted as `TabletPoint` with richer pressure/tilt data.
+            if pen_pointer_info.is_some() {
+                return None;
+            }
+            let buttons_mask = NSEvent::pressedMouseButtons() as u64;
+            PointerEvent::Move(PointerUpdate {
+                pointer: map::pointer_info_primary_for_type(PointerType::Mouse),
+                current: state(buttons_mask, None, None),
+                coalesced: alloc::vec![],
+                predicted: alloc::vec![],
+            })
+        }
+        NSEventType::MouseEntered => {
+            PointerEvent::Enter(map::pointer_info_primary_for_type(PointerType::Mouse))
+        }
+        NSEventType::MouseExited => {
+            PointerEvent::Leave(map::pointer_info_primary_for_type(PointerType::Mouse))
+        }
+        NSEventType::ScrollWheel => {
+            let precise = e.hasPreciseScrollingDeltas();
+            // `scrollingDeltaX/Y` already include AppKit's natural-scrolling
+            // preference adjustment. Preserve the sign to match winit's macOS
+            // backend and leave content movement policy to downstream users.
+            let dx = e.scrollingDeltaX();
+            let dy = e.scrollingDeltaY();
+            let buttons_mask = NSEvent::pressedMouseButtons() as u64;
+            let state = state(buttons_mask, None, None);
+            PointerEvent::Scroll(PointerScrollEvent {
+                pointer: map::pointer_info_primary_for_type(PointerType::Mouse),
+                delta: map::pointer_scroll_delta_from_raw(state.scale_factor, precise, dx, dy),
+                state,
+            })
+        }
+        NSEventType::Magnify => {
+            let buttons_mask = NSEvent::pressedMouseButtons() as u64;
+            let state = state(buttons_mask, None, None);
+            let magnification = e.magnification();
+            if !magnification.is_finite() {
+                return None;
+            }
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "AppKit reports magnification as f64; ui-events uses f32"
+            )]
+            let factor = magnification as f32;
+            PointerEvent::Gesture(PointerGestureEvent {
+                pointer: map::pointer_info_primary_for_type(PointerType::Mouse),
+                gesture: PointerGesture::Pinch(factor),
+                state,
+            })
+        }
+        NSEventType::Rotate => {
+            // AppKit reports rotation in degrees, where positive values are counterclockwise.
+            // ui-events uses clockwise radians.
+            let buttons_mask = NSEvent::pressedMouseButtons() as u64;
+            let state = state(buttons_mask, None, None);
+            let degrees = e.rotation() as f64;
+            if !degrees.is_finite() {
+                return None;
+            }
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "AppKit reports degrees as f64; ui-events stores radians as f32"
+            )]
+            let radians_clockwise = (-degrees).to_radians() as f32;
+            PointerEvent::Gesture(PointerGestureEvent {
+                pointer: map::pointer_info_primary_for_type(PointerType::Mouse),
+                gesture: PointerGesture::Rotate(radians_clockwise),
+                state,
+            })
+        }
+        NSEventType::TabletPoint => {
+            let pointing_device = e.pointingDeviceType();
+            let pointer_type = pointer_type_from_pointing_device(pointing_device);
+            let buttons_mask = pen_buttons_mask(pointing_device, e.buttonMask().0 as u64);
+            let pressure = Some(e.pressure() as f64);
+            let tangential = Some(e.tangentialPressure() as f64);
+            let tilt = e.tilt();
+            let mut current = state(buttons_mask, pressure, tangential);
+            current.orientation = map::orientation_from_tilt_fraction(tilt.x, tilt.y);
+            let pointer = map::pointer_info_from_platform_ids(
+                pointer_type,
+                Some(e.uniqueID()),
+                Some(e.deviceID() as u64),
+            );
+            PointerEvent::Move(PointerUpdate {
+                pointer,
+                current,
+                coalesced: alloc::vec![],
+                predicted: alloc::vec![],
+            })
+        }
+        NSEventType::TabletProximity => {
+            let pointing_device = e.pointingDeviceType();
+            let pointer_type = pointer_type_from_pointing_device(pointing_device);
+            let pointer = map::pointer_info_from_platform_ids(
+                pointer_type,
+                Some(e.uniqueID()),
+                Some(e.deviceID() as u64),
+            );
+            if e.isEnteringProximity() {
+                PointerEvent::Enter(pointer)
+            } else {
+                PointerEvent::Leave(pointer)
+            }
+        }
+        _ => return None,
+    })
+}
+
+fn map_virtual_keycode_to_code_named_location(code: u16) -> (Code, Option<NamedKey>, Location) {
+    use vk as K;
+    match code {
+        K::ANSI_A => (Code::KeyA, None, Location::Standard),
+        K::ANSI_S => (Code::KeyS, None, Location::Standard),
+        K::ANSI_D => (Code::KeyD, None, Location::Standard),
+        K::ANSI_F => (Code::KeyF, None, Location::Standard),
+        K::ANSI_H => (Code::KeyH, None, Location::Standard),
+        K::ANSI_G => (Code::KeyG, None, Location::Standard),
+        K::ANSI_Z => (Code::KeyZ, None, Location::Standard),
+        K::ANSI_X => (Code::KeyX, None, Location::Standard),
+        K::ANSI_C => (Code::KeyC, None, Location::Standard),
+        K::ANSI_V => (Code::KeyV, None, Location::Standard),
+        K::ANSI_B => (Code::KeyB, None, Location::Standard),
+        K::ANSI_Q => (Code::KeyQ, None, Location::Standard),
+        K::ANSI_W => (Code::KeyW, None, Location::Standard),
+        K::ANSI_E => (Code::KeyE, None, Location::Standard),
+        K::ANSI_R => (Code::KeyR, None, Location::Standard),
+        K::ANSI_Y => (Code::KeyY, None, Location::Standard),
+        K::ANSI_T => (Code::KeyT, None, Location::Standard),
+        K::ANSI_1 => (Code::Digit1, None, Location::Standard),
+        K::ANSI_2 => (Code::Digit2, None, Location::Standard),
+        K::ANSI_3 => (Code::Digit3, None, Location::Standard),
+        K::ANSI_4 => (Code::Digit4, None, Location::Standard),
+        K::ANSI_6 => (Code::Digit6, None, Location::Standard),
+        K::ANSI_5 => (Code::Digit5, None, Location::Standard),
+        K::ANSI_EQUAL => (Code::Equal, None, Location::Standard),
+        K::ANSI_9 => (Code::Digit9, None, Location::Standard),
+        K::ANSI_7 => (Code::Digit7, None, Location::Standard),
+        K::ANSI_MINUS => (Code::Minus, None, Location::Standard),
+        K::ANSI_8 => (Code::Digit8, None, Location::Standard),
+        K::ANSI_0 => (Code::Digit0, None, Location::Standard),
+        K::ANSI_RIGHT_BRACKET => (Code::BracketRight, None, Location::Standard),
+        K::ANSI_O => (Code::KeyO, None, Location::Standard),
+        K::ANSI_U => (Code::KeyU, None, Location::Standard),
+        K::ANSI_LEFT_BRACKET => (Code::BracketLeft, None, Location::Standard),
+        K::ANSI_I => (Code::KeyI, None, Location::Standard),
+        K::ANSI_P => (Code::KeyP, None, Location::Standard),
+        K::RETURN => (Code::Enter, Some(NamedKey::Enter), Location::Standard),
+        K::ANSI_L => (Code::KeyL, None, Location::Standard),
+        K::ANSI_J => (Code::KeyJ, None, Location::Standard),
+        K::ANSI_QUOTE => (Code::Quote, None, Location::Standard),
+        K::ANSI_K => (Code::KeyK, None, Location::Standard),
+        K::ANSI_SEMICOLON => (Code::Semicolon, None, Location::Standard),
+        K::ANSI_BACKSLASH => (Code::Backslash, None, Location::Standard),
+        K::ANSI_COMMA => (Code::Comma, None, Location::Standard),
+        K::ANSI_SLASH => (Code::Slash, None, Location::Standard),
+        K::ANSI_N => (Code::KeyN, None, Location::Standard),
+        K::ANSI_M => (Code::KeyM, None, Location::Standard),
+        K::ANSI_PERIOD => (Code::Period, None, Location::Standard),
+        K::TAB => (Code::Tab, Some(NamedKey::Tab), Location::Standard),
+        // Space is treated as a character rather than NamedKey.
+        K::SPACE => (Code::Space, None, Location::Standard),
+        K::ANSI_GRAVE => (Code::Backquote, None, Location::Standard),
+        K::DELETE => (
+            Code::Backspace,
+            Some(NamedKey::Backspace),
+            Location::Standard,
+        ),
+        K::ESCAPE => (Code::Escape, Some(NamedKey::Escape), Location::Standard),
+        K::RIGHT_COMMAND => (Code::MetaRight, Some(NamedKey::Meta), Location::Right),
+        K::COMMAND => (Code::MetaLeft, Some(NamedKey::Meta), Location::Left),
+        K::SHIFT => (Code::ShiftLeft, Some(NamedKey::Shift), Location::Left),
+        K::CAPS_LOCK => (Code::CapsLock, Some(NamedKey::CapsLock), Location::Standard),
+        K::OPTION => (Code::AltLeft, Some(NamedKey::Alt), Location::Left),
+        K::CONTROL => (Code::ControlLeft, Some(NamedKey::Control), Location::Left),
+        K::RIGHT_SHIFT => (Code::ShiftRight, Some(NamedKey::Shift), Location::Right),
+        K::RIGHT_OPTION => (Code::AltRight, Some(NamedKey::Alt), Location::Right),
+        K::RIGHT_CONTROL => (Code::ControlRight, Some(NamedKey::Control), Location::Right),
+        K::FUNCTION => (Code::Fn, Some(NamedKey::Fn), Location::Standard),
+        K::ANSI_KEYPAD_DECIMAL => (Code::NumpadDecimal, None, Location::Numpad),
+        K::ANSI_KEYPAD_MULTIPLY => (Code::NumpadMultiply, None, Location::Numpad),
+        K::ANSI_KEYPAD_PLUS => (Code::NumpadAdd, None, Location::Numpad),
+        K::ANSI_KEYPAD_CLEAR => (Code::NumLock, Some(NamedKey::NumLock), Location::Numpad),
+        K::ANSI_KEYPAD_DIVIDE => (Code::NumpadDivide, None, Location::Numpad),
+        K::ANSI_KEYPAD_ENTER => (Code::NumpadEnter, Some(NamedKey::Enter), Location::Numpad),
+        K::ANSI_KEYPAD_MINUS => (Code::NumpadSubtract, None, Location::Numpad),
+        K::ANSI_KEYPAD_EQUALS => (Code::NumpadEqual, None, Location::Numpad),
+        K::ANSI_KEYPAD_0 => (Code::Numpad0, None, Location::Numpad),
+        K::ANSI_KEYPAD_1 => (Code::Numpad1, None, Location::Numpad),
+        K::ANSI_KEYPAD_2 => (Code::Numpad2, None, Location::Numpad),
+        K::ANSI_KEYPAD_3 => (Code::Numpad3, None, Location::Numpad),
+        K::ANSI_KEYPAD_4 => (Code::Numpad4, None, Location::Numpad),
+        K::ANSI_KEYPAD_5 => (Code::Numpad5, None, Location::Numpad),
+        K::ANSI_KEYPAD_6 => (Code::Numpad6, None, Location::Numpad),
+        K::ANSI_KEYPAD_7 => (Code::Numpad7, None, Location::Numpad),
+        K::ANSI_KEYPAD_8 => (Code::Numpad8, None, Location::Numpad),
+        K::ANSI_KEYPAD_9 => (Code::Numpad9, None, Location::Numpad),
+        K::F1 => (Code::F1, Some(NamedKey::F1), Location::Standard),
+        K::F2 => (Code::F2, Some(NamedKey::F2), Location::Standard),
+        K::F3 => (Code::F3, Some(NamedKey::F3), Location::Standard),
+        K::F4 => (Code::F4, Some(NamedKey::F4), Location::Standard),
+        K::F5 => (Code::F5, Some(NamedKey::F5), Location::Standard),
+        K::F6 => (Code::F6, Some(NamedKey::F6), Location::Standard),
+        K::F7 => (Code::F7, Some(NamedKey::F7), Location::Standard),
+        K::F8 => (Code::F8, Some(NamedKey::F8), Location::Standard),
+        K::F9 => (Code::F9, Some(NamedKey::F9), Location::Standard),
+        K::F10 => (Code::F10, Some(NamedKey::F10), Location::Standard),
+        K::F11 => (Code::F11, Some(NamedKey::F11), Location::Standard),
+        K::F12 => (Code::F12, Some(NamedKey::F12), Location::Standard),
+        K::F13 => (Code::F13, Some(NamedKey::F13), Location::Standard),
+        K::F14 => (Code::F14, Some(NamedKey::F14), Location::Standard),
+        K::F15 => (Code::F15, Some(NamedKey::F15), Location::Standard),
+        K::F16 => (Code::F16, Some(NamedKey::F16), Location::Standard),
+        K::F17 => (Code::F17, Some(NamedKey::F17), Location::Standard),
+        K::HELP => (Code::Help, Some(NamedKey::Help), Location::Standard),
+        K::HOME => (Code::Home, Some(NamedKey::Home), Location::Standard),
+        K::PAGE_UP => (Code::PageUp, Some(NamedKey::PageUp), Location::Standard),
+        K::FORWARD_DELETE => (Code::Delete, Some(NamedKey::Delete), Location::Standard),
+        K::END => (Code::End, Some(NamedKey::End), Location::Standard),
+        K::PAGE_DOWN => (Code::PageDown, Some(NamedKey::PageDown), Location::Standard),
+        K::ARROW_LEFT => (
+            Code::ArrowLeft,
+            Some(NamedKey::ArrowLeft),
+            Location::Standard,
+        ),
+        K::ARROW_RIGHT => (
+            Code::ArrowRight,
+            Some(NamedKey::ArrowRight),
+            Location::Standard,
+        ),
+        K::ARROW_DOWN => (
+            Code::ArrowDown,
+            Some(NamedKey::ArrowDown),
+            Location::Standard,
+        ),
+        K::ARROW_UP => (Code::ArrowUp, Some(NamedKey::ArrowUp), Location::Standard),
+        _ => (
+            Code::Unidentified,
+            Some(NamedKey::Unidentified),
+            Location::Standard,
+        ),
+    }
+}
+
+fn map_modifier_toggle(code: u16) -> Option<(Code, NamedKey, Location, NSEventModifierFlags)> {
+    use vk as K;
+    Some(match code {
+        K::SHIFT => (
+            Code::ShiftLeft,
+            NamedKey::Shift,
+            Location::Left,
+            NSEventModifierFlags::Shift,
+        ),
+        K::RIGHT_SHIFT => (
+            Code::ShiftRight,
+            NamedKey::Shift,
+            Location::Right,
+            NSEventModifierFlags::Shift,
+        ),
+        K::CONTROL => (
+            Code::ControlLeft,
+            NamedKey::Control,
+            Location::Left,
+            NSEventModifierFlags::Control,
+        ),
+        K::RIGHT_CONTROL => (
+            Code::ControlRight,
+            NamedKey::Control,
+            Location::Right,
+            NSEventModifierFlags::Control,
+        ),
+        K::OPTION => (
+            Code::AltLeft,
+            NamedKey::Alt,
+            Location::Left,
+            NSEventModifierFlags::Option,
+        ),
+        K::RIGHT_OPTION => (
+            Code::AltRight,
+            NamedKey::Alt,
+            Location::Right,
+            NSEventModifierFlags::Option,
+        ),
+        K::COMMAND => (
+            Code::MetaLeft,
+            NamedKey::Meta,
+            Location::Left,
+            NSEventModifierFlags::Command,
+        ),
+        K::RIGHT_COMMAND => (
+            Code::MetaRight,
+            NamedKey::Meta,
+            Location::Right,
+            NSEventModifierFlags::Command,
+        ),
+        K::CAPS_LOCK => (
+            Code::CapsLock,
+            NamedKey::CapsLock,
+            Location::Standard,
+            NSEventModifierFlags::CapsLock,
+        ),
+        _ => return None,
+    })
+}
+
+fn key_from_appkit_strings(
+    named: Option<NamedKey>,
+    characters: Option<&str>,
+    unmodified_characters: Option<&str>,
+) -> Key {
+    if let Some(named) = named {
+        Key::Named(named)
+    } else if let Some(chars) = characters.and_then(single_character_string) {
+        Key::Character(chars.into())
+    } else if let Some(chars) = unmodified_characters.and_then(single_character_string) {
+        Key::Character(chars.into())
+    } else {
+        Key::Named(NamedKey::Unidentified)
+    }
+}
+
+fn single_character_string(s: &str) -> Option<&str> {
+    (s.chars().count() == 1).then_some(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::cell::Cell;
+    use ui_events::pointer::{PointerButton, PointerId, PointerType};
+
+    #[test]
+    fn tablet_pen_mouse_events_keep_pen_identity() {
+        let pointer = pen_pointer_info_for_mouse_event(
+            NSEventSubtype::TabletPoint,
+            NSPointingDeviceType::Pen,
+            41,
+            7,
+        )
+        .expect("tablet-pen mouse events should preserve pen identity");
+        assert_eq!(pointer.pointer_type, PointerType::Pen);
+        assert_ne!(pointer.pointer_id, Some(PointerId::PRIMARY));
+        assert!(pointer.persistent_device_id.is_some());
+    }
+
+    #[test]
+    fn ordinary_mouse_events_do_not_claim_pen_identity() {
+        assert_eq!(
+            pen_pointer_info_for_mouse_event(
+                NSEventSubtype::MouseEvent,
+                NSPointingDeviceType::Pen,
+                41,
+                7,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn eraser_transition_uses_pen_eraser_button() {
+        assert_eq!(
+            pen_transition_button(NSPointingDeviceType::Eraser, 0),
+            Some(PointerButton::PenEraser)
+        );
+    }
+
+    #[test]
+    fn mouse_down_state_includes_transition_button() {
+        assert_eq!(mouse_buttons_after_down(0, 0), 1);
+        assert_eq!(mouse_buttons_after_down(1 << 1, 0), 0b11);
+    }
+
+    #[test]
+    fn mouse_up_state_excludes_transition_button() {
+        assert_eq!(mouse_buttons_after_up(1, 0), 0);
+        assert_eq!(mouse_buttons_after_up(0b11, 0), 0b10);
+    }
+
+    #[test]
+    fn mouse_transition_state_ignores_invalid_button_numbers() {
+        assert_eq!(mouse_buttons_after_down(0b1010, -1), 0b1010);
+        assert_eq!(mouse_buttons_after_up(0b1010, 32), 0b1010);
+    }
+
+    #[test]
+    fn click_count_is_read_for_mouse_button_events() {
+        let called = Cell::new(false);
+        let count = click_count_for_mouse_button_event(NSEventType::LeftMouseDown, || {
+            called.set(true);
+            2
+        });
+
+        assert_eq!(count, 2);
+        assert!(called.get());
+    }
+
+    #[test]
+    fn scroll_click_count_is_zero_without_reading_event() {
+        let called = Cell::new(false);
+        let count = click_count_for_mouse_button_event(NSEventType::ScrollWheel, || {
+            called.set(true);
+            2
+        });
+
+        assert_eq!(count, 0);
+        assert!(!called.get());
+    }
+
+    #[test]
+    fn pen_pointer_info_is_read_for_mouse_events() {
+        let called = Cell::new(false);
+        let pointer = pen_pointer_info_for_mouse_nsevent(NSEventType::LeftMouseDragged, || {
+            called.set(true);
+            Some(map::pointer_info_from_platform_ids(
+                PointerType::Pen,
+                Some(1),
+                Some(2),
+            ))
+        });
+
+        assert!(pointer.is_some());
+        assert!(called.get());
+    }
+
+    #[test]
+    fn scroll_pen_pointer_info_is_not_read() {
+        let called = Cell::new(false);
+        let pointer = pen_pointer_info_for_mouse_nsevent(NSEventType::ScrollWheel, || {
+            called.set(true);
+            Some(map::pointer_info_from_platform_ids(
+                PointerType::Pen,
+                Some(1),
+                Some(2),
+            ))
+        });
+
+        assert_eq!(pointer, None);
+        assert!(!called.get());
+    }
+
+    #[test]
+    fn left_shift_modifier_toggle_preserves_code_and_location() {
+        assert_eq!(
+            map_modifier_toggle(vk::SHIFT),
+            Some((
+                Code::ShiftLeft,
+                NamedKey::Shift,
+                Location::Left,
+                NSEventModifierFlags::Shift,
+            ))
+        );
+    }
+
+    #[test]
+    fn right_command_modifier_toggle_preserves_code_and_location() {
+        assert_eq!(
+            map_modifier_toggle(vk::RIGHT_COMMAND),
+            Some((
+                Code::MetaRight,
+                NamedKey::Meta,
+                Location::Right,
+                NSEventModifierFlags::Command,
+            ))
+        );
+    }
+
+    #[test]
+    fn produced_characters_take_priority_over_unmodified_fallback() {
+        assert_eq!(
+            key_from_appkit_strings(None, Some("ß"), Some("s")),
+            Key::Character("ß".into())
+        );
+    }
+
+    #[test]
+    fn single_unmodified_character_is_used_as_fallback() {
+        assert_eq!(
+            key_from_appkit_strings(None, None, Some("a")),
+            Key::Character("a".into())
+        );
+    }
+
+    #[test]
+    fn multi_scalar_characters_fall_back_to_unmodified_character() {
+        assert_eq!(
+            key_from_appkit_strings(None, Some("de"), Some("d")),
+            Key::Character("d".into())
+        );
+    }
+
+    #[test]
+    fn keypad_enter_maps_to_numpad_location() {
+        assert_eq!(
+            map_virtual_keycode_to_code_named_location(vk::ANSI_KEYPAD_ENTER),
+            (Code::NumpadEnter, Some(NamedKey::Enter), Location::Numpad)
+        );
+    }
+
+    #[test]
+    fn f13_preserves_named_key() {
+        assert_eq!(
+            map_virtual_keycode_to_code_named_location(vk::F13),
+            (Code::F13, Some(NamedKey::F13), Location::Standard)
+        );
+    }
+}

--- a/ui-events-appkit/src/appkit/keycodes.rs
+++ b/ui-events-appkit/src/appkit/keycodes.rs
@@ -1,0 +1,120 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! macOS virtual keycode constants used by AppKit's `NSEvent::keyCode()`.
+//!
+//! These mirror the classic kVK_* values from HIToolbox/Events.h. Keeping them
+//! named avoids sprinkling raw numeric literals throughout the mapping tables.
+
+// Letters / punctuation
+pub(super) const ANSI_A: u16 = 0;
+pub(super) const ANSI_S: u16 = 1;
+pub(super) const ANSI_D: u16 = 2;
+pub(super) const ANSI_F: u16 = 3;
+pub(super) const ANSI_H: u16 = 4;
+pub(super) const ANSI_G: u16 = 5;
+pub(super) const ANSI_Z: u16 = 6;
+pub(super) const ANSI_X: u16 = 7;
+pub(super) const ANSI_C: u16 = 8;
+pub(super) const ANSI_V: u16 = 9;
+pub(super) const ANSI_B: u16 = 11;
+pub(super) const ANSI_Q: u16 = 12;
+pub(super) const ANSI_W: u16 = 13;
+pub(super) const ANSI_E: u16 = 14;
+pub(super) const ANSI_R: u16 = 15;
+pub(super) const ANSI_Y: u16 = 16;
+pub(super) const ANSI_T: u16 = 17;
+pub(super) const ANSI_1: u16 = 18;
+pub(super) const ANSI_2: u16 = 19;
+pub(super) const ANSI_3: u16 = 20;
+pub(super) const ANSI_4: u16 = 21;
+pub(super) const ANSI_6: u16 = 22;
+pub(super) const ANSI_5: u16 = 23;
+pub(super) const ANSI_EQUAL: u16 = 24;
+pub(super) const ANSI_9: u16 = 25;
+pub(super) const ANSI_7: u16 = 26;
+pub(super) const ANSI_MINUS: u16 = 27;
+pub(super) const ANSI_8: u16 = 28;
+pub(super) const ANSI_0: u16 = 29;
+pub(super) const ANSI_RIGHT_BRACKET: u16 = 30;
+pub(super) const ANSI_O: u16 = 31;
+pub(super) const ANSI_U: u16 = 32;
+pub(super) const ANSI_LEFT_BRACKET: u16 = 33;
+pub(super) const ANSI_I: u16 = 34;
+pub(super) const ANSI_P: u16 = 35;
+pub(super) const RETURN: u16 = 36;
+pub(super) const ANSI_L: u16 = 37;
+pub(super) const ANSI_J: u16 = 38;
+pub(super) const ANSI_QUOTE: u16 = 39;
+pub(super) const ANSI_K: u16 = 40;
+pub(super) const ANSI_SEMICOLON: u16 = 41;
+pub(super) const ANSI_BACKSLASH: u16 = 42;
+pub(super) const ANSI_COMMA: u16 = 43;
+pub(super) const ANSI_SLASH: u16 = 44;
+pub(super) const ANSI_N: u16 = 45;
+pub(super) const ANSI_M: u16 = 46;
+pub(super) const ANSI_PERIOD: u16 = 47;
+pub(super) const TAB: u16 = 48;
+pub(super) const SPACE: u16 = 49;
+pub(super) const ANSI_GRAVE: u16 = 50;
+pub(super) const DELETE: u16 = 51; // Backspace
+pub(super) const ESCAPE: u16 = 53;
+pub(super) const RIGHT_COMMAND: u16 = 54; // MetaRight
+pub(super) const COMMAND: u16 = 55; // MetaLeft
+pub(super) const SHIFT: u16 = 56; // ShiftLeft
+pub(super) const CAPS_LOCK: u16 = 57;
+pub(super) const OPTION: u16 = 58; // AltLeft
+pub(super) const CONTROL: u16 = 59; // ControlLeft
+pub(super) const RIGHT_SHIFT: u16 = 60;
+pub(super) const RIGHT_OPTION: u16 = 61; // AltRight
+pub(super) const RIGHT_CONTROL: u16 = 62; // ControlRight
+pub(super) const FUNCTION: u16 = 63; // Fn
+
+// Keypad
+pub(super) const ANSI_KEYPAD_DECIMAL: u16 = 65;
+pub(super) const ANSI_KEYPAD_MULTIPLY: u16 = 67;
+pub(super) const ANSI_KEYPAD_PLUS: u16 = 69;
+pub(super) const ANSI_KEYPAD_CLEAR: u16 = 71;
+pub(super) const ANSI_KEYPAD_DIVIDE: u16 = 75;
+pub(super) const ANSI_KEYPAD_ENTER: u16 = 76;
+pub(super) const ANSI_KEYPAD_MINUS: u16 = 78;
+pub(super) const ANSI_KEYPAD_EQUALS: u16 = 81;
+pub(super) const ANSI_KEYPAD_0: u16 = 82;
+pub(super) const ANSI_KEYPAD_1: u16 = 83;
+pub(super) const ANSI_KEYPAD_2: u16 = 84;
+pub(super) const ANSI_KEYPAD_3: u16 = 85;
+pub(super) const ANSI_KEYPAD_4: u16 = 86;
+pub(super) const ANSI_KEYPAD_5: u16 = 87;
+pub(super) const ANSI_KEYPAD_6: u16 = 88;
+pub(super) const ANSI_KEYPAD_7: u16 = 89;
+pub(super) const ANSI_KEYPAD_8: u16 = 91;
+pub(super) const ANSI_KEYPAD_9: u16 = 92;
+
+// Navigation / function keys
+pub(super) const F17: u16 = 64;
+pub(super) const F5: u16 = 96;
+pub(super) const F6: u16 = 97;
+pub(super) const F7: u16 = 98;
+pub(super) const F3: u16 = 99;
+pub(super) const F8: u16 = 100;
+pub(super) const F9: u16 = 101;
+pub(super) const F11: u16 = 103;
+pub(super) const F13: u16 = 105;
+pub(super) const F16: u16 = 106;
+pub(super) const F14: u16 = 107;
+pub(super) const F10: u16 = 109;
+pub(super) const F12: u16 = 111;
+pub(super) const F15: u16 = 113;
+pub(super) const HELP: u16 = 114;
+pub(super) const HOME: u16 = 115;
+pub(super) const PAGE_UP: u16 = 116;
+pub(super) const FORWARD_DELETE: u16 = 117; // Delete (Forward)
+pub(super) const F4: u16 = 118;
+pub(super) const END: u16 = 119;
+pub(super) const F2: u16 = 120;
+pub(super) const PAGE_DOWN: u16 = 121;
+pub(super) const F1: u16 = 122;
+pub(super) const ARROW_LEFT: u16 = 123;
+pub(super) const ARROW_RIGHT: u16 = 124;
+pub(super) const ARROW_DOWN: u16 = 125;
+pub(super) const ARROW_UP: u16 = 126;

--- a/ui-events-appkit/src/input_responder.rs
+++ b/ui-events-appkit/src/input_responder.rs
@@ -1,0 +1,207 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Reusable `AppKit` responder for pointer, scroll, gesture, tablet, and
+//! keyboard input.
+
+use alloc::boxed::Box;
+
+use objc2::rc::Retained;
+use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send};
+use objc2_app_kit::{NSEvent, NSResponder};
+use ui_events::keyboard::KeyboardEvent;
+use ui_events::pointer::PointerEvent;
+
+use crate::{keyboard_event_from_nsevent, pointer_event_from_nsevent_at_position};
+
+/// Host-side event sink for [`AppKitInputResponder`].
+pub trait AppKitInputResponderHost {
+    /// Handle a translated `AppKit` keyboard event.
+    fn handle_keyboard_event(&self, event: KeyboardEvent);
+
+    /// Handle a translated `AppKit` pointer, scroll, gesture, or tablet event.
+    fn handle_pointer_event(&self, event: PointerEvent);
+
+    /// Return the pointer position for `event` in the host coordinate space,
+    /// measured in logical AppKit points.
+    ///
+    /// `NSEvent::locationInWindow` is window-relative. Hosts backed by an
+    /// `NSView` should usually convert that point with
+    /// `view.convertPoint_fromView(event.locationInWindow(), None)` before
+    /// returning it here.
+    fn pointer_position(&self, event: &NSEvent) -> (f64, f64);
+
+    /// Return the scale factor used when converting `AppKit` pointer positions
+    /// from logical points into physical pixels.
+    fn pointer_scale_factor(&self) -> f64;
+}
+
+#[doc(hidden)]
+pub struct InputResponderState {
+    host: Box<dyn AppKitInputResponderHost>,
+}
+
+impl core::fmt::Debug for InputResponderState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputResponderState")
+            .field("host", &"<dyn AppKitInputResponderHost>")
+            .finish()
+    }
+}
+
+define_class!(
+    #[unsafe(super = NSResponder)]
+    #[thread_kind = objc2::MainThreadOnly]
+    #[name = "UIEventsAppKitInputResponder"]
+    #[ivars = InputResponderState]
+    #[doc = "Reusable `AppKit` responder for pointer, scroll, gesture, tablet, and keyboard input."]
+    pub struct AppKitInputResponder;
+
+    impl AppKitInputResponder {
+        #[unsafe(method(acceptsFirstResponder))]
+        fn accepts_first_responder(&self) -> bool {
+            true
+        }
+
+        #[unsafe(method(keyDown:))]
+        fn key_down(&self, event: &NSEvent) {
+            self.handle_keyboard_nsevent(event);
+        }
+
+        #[unsafe(method(keyUp:))]
+        fn key_up(&self, event: &NSEvent) {
+            self.handle_keyboard_nsevent(event);
+        }
+
+        #[unsafe(method(flagsChanged:))]
+        fn flags_changed(&self, event: &NSEvent) {
+            self.handle_keyboard_nsevent(event);
+        }
+
+        #[unsafe(method(mouseDown:))]
+        fn mouse_down(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(mouseDragged:))]
+        fn mouse_dragged(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(mouseMoved:))]
+        fn mouse_moved(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(mouseUp:))]
+        fn mouse_up(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(rightMouseDown:))]
+        fn right_mouse_down(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(rightMouseDragged:))]
+        fn right_mouse_dragged(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(rightMouseUp:))]
+        fn right_mouse_up(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(otherMouseDown:))]
+        fn other_mouse_down(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(otherMouseDragged:))]
+        fn other_mouse_dragged(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(otherMouseUp:))]
+        fn other_mouse_up(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(scrollWheel:))]
+        fn scroll_wheel(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(magnifyWithEvent:))]
+        fn magnify_with_event(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(rotateWithEvent:))]
+        fn rotate_with_event(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(tabletPoint:))]
+        fn tablet_point(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(tabletProximity:))]
+        fn tablet_proximity(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(mouseEntered:))]
+        fn mouse_entered(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+
+        #[unsafe(method(mouseExited:))]
+        fn mouse_exited(&self, event: &NSEvent) {
+            self.handle_pointer_nsevent(event);
+        }
+    }
+);
+
+impl AppKitInputResponder {
+    /// Create a reusable `AppKit` responder for pointer, scroll, gesture,
+    /// tablet, and keyboard input.
+    pub fn new(mtm: MainThreadMarker, host: Box<dyn AppKitInputResponderHost>) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(InputResponderState { host });
+        // SAFETY: `NSResponder` has no additional initialization requirements.
+        unsafe { msg_send![super(this), init] }
+    }
+
+    /// Translate an `AppKit` keyboard `NSEvent` and forward it to the host.
+    pub fn handle_keyboard_nsevent(&self, event: &NSEvent) {
+        if let Some(event) = keyboard_event_from_nsevent(event) {
+            self.ivars().host.handle_keyboard_event(event);
+        }
+    }
+
+    /// Translate an `AppKit` pointer-related `NSEvent` and forward it to the host.
+    pub fn handle_pointer_nsevent(&self, event: &NSEvent) {
+        let (x, y) = self.ivars().host.pointer_position(event);
+        if let Some(event) = pointer_event_from_nsevent_at_position(
+            event,
+            self.ivars().host.pointer_scale_factor(),
+            x,
+            y,
+        ) {
+            self.ivars().host.handle_pointer_event(event);
+        }
+    }
+
+    /// Set the responder that should receive events this responder does not handle.
+    ///
+    /// # Safety
+    ///
+    /// AppKit stores `next_responder` unretained. The caller must ensure that
+    /// the responder remains alive while AppKit can traverse this responder
+    /// chain.
+    pub unsafe fn set_following_responder(&self, next_responder: Option<&NSResponder>) {
+        unsafe { self.setNextResponder(next_responder) };
+    }
+}

--- a/ui-events-appkit/src/lib.rs
+++ b/ui-events-appkit/src/lib.rs
@@ -1,0 +1,117 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! AppKit (macOS) adapter using `objc2`.
+//!
+//! This crate provides lightweight helpers to convert AppKit events into
+//! [`ui-events`] types, mirroring the style of the `ui-events-web` and
+//! `ui-events-winit` adapters.
+//!
+//! It does not provide an `NSView` implementation for you. Instead, your
+//! AppKit view or responder should call these helpers from the corresponding
+//! AppKit callbacks.
+//!
+//! Currently supported:
+//!
+//! - Pointer (mouse/pen) down/up/move/enter/leave/scroll
+//! - Trackpad gestures: magnify (pinch) and rotate
+//! - Keyboard down/up
+//! - `AppKitInputResponder`, a reusable `NSResponder` for pointer, scroll,
+//!   gesture, tablet, and keyboard input
+//!
+//! `AppKitInputResponder` intentionally does not implement text input, IME, or
+//! edit-command protocols.
+//!
+//! ## Feature Policy
+//!
+//! - `std` is enabled by default.
+//! - `libm` is required for `no_std` builds because tablet tilt orientation uses
+//!   trigonometry.
+//! - With `default-features = false`, the crate remains `no_std` with `alloc`
+//!   and still compiles on non-macOS targets because the `objc2` dependencies
+//!   are behind `target_os = "macos"`.
+//! - On macOS targets, the `objc2*` crates are compiled with their `std` feature
+//!   enabled to support Objective-C runtime integration.
+//! - Defaults avoid pulling in unnecessary APIs by disabling default features
+//!   for `objc2*` crates and enabling only the AppKit symbols this crate uses.
+//!
+//! ## Pointer Notes
+//!
+//! - Pointer positions come from `NSEvent::locationInWindow`, scaled from
+//!   points into physical pixels but not converted into a specific `NSView`.
+//!   `pointer_event_from_nsevent_at_position` accepts a caller-provided
+//!   coordinate, and `AppKitInputResponderHost` requires the host to provide
+//!   the position in its own coordinate space.
+//! - Event timestamps use AppKit's monotonic seconds-since-boot timebase, not
+//!   Unix epoch time.
+//! - Mouse button down/up click counts use AppKit's `clickCount` directly.
+//!   Other pointer event kinds, including scroll events, use `0` without
+//!   querying click metadata from AppKit.
+//! - Mouse events may query AppKit tablet metadata when AppKit reports tablet
+//!   mouse-event subtypes. Scroll events do not query tablet metadata.
+//! - Tablet tilt uses AppKit's `NSEvent::tilt` fractions, where `0.0` is
+//!   perpendicular and `1.0` is parallel to the surface along that axis.
+//!
+//! ## Scroll Deltas
+//!
+//! - Scroll deltas preserve AppKit's `scrollingDeltaX/Y` sign, which already
+//!   reflects the user's natural-scrolling preference and matches the macOS
+//!   path used by `winit`.
+//! - When `hasPreciseScrollingDeltas` is true, deltas map to
+//!   [`ScrollDelta::PixelDelta`]. Otherwise, they map to
+//!   [`ScrollDelta::LineDelta`].
+//!
+//! ## Gestures
+//!
+//! - Magnify gesture events map to [`PointerGesture::Pinch`](ui_events::pointer::PointerGesture::Pinch)
+//!   using AppKit's per-event `magnification` delta.
+//! - Rotate gesture events map to
+//!   [`PointerGesture::Rotate`](ui_events::pointer::PointerGesture::Rotate) in
+//!   clockwise radians.
+//!
+//! ## Tablet Events
+//!
+//! - `NSEventType::TabletPoint` maps to [`PointerType::Pen`] with pressure,
+//!   tangential pressure, and orientation derived from AppKit tilt fractions.
+//! - `NSEventType::TabletProximity` maps to `PointerEvent::Enter` or
+//!   `PointerEvent::Leave` based on `isEnteringProximity`.
+//!
+//! ## Keyboard Notes
+//!
+//! - `flagsChanged` uses aggregate modifier flags. Releasing one side of a
+//!   modifier while the other side remains held may still report the key as
+//!   down until this adapter grows device-dependent left/right modifier masks.
+//!
+//! ## High-Level Helpers
+//!
+//! - `AppKitInputResponder`
+//! - `pointer_event_from_nsevent`
+//! - `pointer_event_from_nsevent_at_position`
+//! - `keyboard_event_from_nsevent`
+//!
+//! If you prefer, low-level mappers in [`mapping`] let you build events from
+//! raw values (e.g. coordinates, button number, modifier booleans) without
+//! pulling in AppKit types in your own code.
+//!
+//! [`PointerType::Pen`]: ui_events::pointer::PointerType::Pen
+//! [`ScrollDelta::LineDelta`]: ui_events::ScrollDelta::LineDelta
+//! [`ScrollDelta::PixelDelta`]: ui_events::ScrollDelta::PixelDelta
+//! [`ui-events`]: https://docs.rs/ui-events/
+
+#![allow(unsafe_code, reason = "We access platform libraries using ffi.")]
+#![no_std]
+
+extern crate alloc;
+
+pub mod mapping;
+
+#[cfg(target_os = "macos")]
+pub mod appkit;
+#[cfg(target_os = "macos")]
+pub mod input_responder;
+#[cfg(target_os = "macos")]
+pub use appkit::{
+    keyboard_event_from_nsevent, pointer_event_from_nsevent, pointer_event_from_nsevent_at_position,
+};
+#[cfg(target_os = "macos")]
+pub use input_responder::{AppKitInputResponder, AppKitInputResponderHost};

--- a/ui-events-appkit/src/mapping.rs
+++ b/ui-events-appkit/src/mapping.rs
@@ -1,0 +1,144 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! AppKit-specific mapping helpers for building `ui-events` from raw values.
+
+use ui_events::pointer::PointerOrientation;
+pub use ui_events_apple_common::{
+    buttons_from_bitmask, modifiers_from_bools, pointer_info_from_platform_ids,
+    pointer_info_primary_for_type, pointer_scroll_delta_from_raw, pointer_state_from_raw,
+    try_from_button_index,
+};
+
+#[cfg(feature = "std")]
+fn hypot(x: f64, y: f64) -> f64 {
+    x.hypot(y)
+}
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+fn hypot(x: f64, y: f64) -> f64 {
+    libm::hypot(x, y)
+}
+
+#[cfg(feature = "std")]
+fn sqrt(value: f64) -> f64 {
+    value.sqrt()
+}
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+fn sqrt(value: f64) -> f64 {
+    libm::sqrt(value)
+}
+
+#[cfg(feature = "std")]
+fn atan2(y: f64, x: f64) -> f64 {
+    y.atan2(x)
+}
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+fn atan2(y: f64, x: f64) -> f64 {
+    libm::atan2(y, x)
+}
+
+#[cfg(all(not(feature = "std"), not(feature = "libm")))]
+compile_error!("ui-events-appkit requires either the `std` or `libm` feature");
+
+fn wrap_angle_positive(angle: f64) -> f64 {
+    let tau = core::f64::consts::TAU;
+    let wrapped = angle % tau;
+    if wrapped < 0.0 {
+        wrapped + tau
+    } else {
+        wrapped
+    }
+}
+
+/// Convert AppKit tablet tilt fractions into a [`PointerOrientation`].
+///
+/// AppKit tablet events report `NSEvent::tilt` as an x/y fraction in
+/// `-1.0..=1.0`, where `0.0` is perpendicular and `1.0` is parallel to the
+/// surface along that axis. This converts that normalized vector into
+/// spherical altitude/azimuth:
+/// - altitude: 0 is parallel to the surface, π/2 is perpendicular.
+/// - azimuth: 0 is +x, π/2 is +y.
+pub fn orientation_from_tilt_fraction(tilt_x: f64, tilt_y: f64) -> PointerOrientation {
+    let x = finite_or(tilt_x, 0.0).clamp(-1.0, 1.0);
+    let y = finite_or(tilt_y, 0.0).clamp(-1.0, 1.0);
+    let r = hypot(x, y).clamp(0.0, 1.0);
+    let z = sqrt((1.0 - r * r).max(0.0));
+    let altitude = if r == 0.0 {
+        core::f64::consts::FRAC_PI_2
+    } else {
+        atan2(z, r)
+    };
+    let azimuth = if r == 0.0 {
+        core::f64::consts::FRAC_PI_2
+    } else {
+        wrap_angle_positive(atan2(y, x))
+    };
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "AppKit-derived angles are finite; ui-events stores orientation as f32"
+    )]
+    let altitude = altitude as f32;
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "AppKit-derived angles are finite; ui-events stores orientation as f32"
+    )]
+    let azimuth = azimuth as f32;
+
+    PointerOrientation { altitude, azimuth }
+}
+
+fn finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() { value } else { fallback }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ui_events::pointer::{PointerId, PointerType};
+
+    #[test]
+    fn tilt_fraction_zero_is_perpendicular_default_azimuth() {
+        let o = orientation_from_tilt_fraction(0.0, 0.0);
+        assert!((o.altitude as f64 - core::f64::consts::FRAC_PI_2).abs() < 1e-6);
+        assert!((o.azimuth as f64 - core::f64::consts::FRAC_PI_2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn full_x_tilt_fraction_is_parallel() {
+        let o = orientation_from_tilt_fraction(1.0, 0.0);
+        assert!((o.azimuth as f64 - 0.0).abs() < 1e-6);
+        assert!((o.altitude as f64 - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn full_y_tilt_fraction_is_parallel() {
+        let o = orientation_from_tilt_fraction(0.0, 1.0);
+        assert!((o.azimuth as f64 - core::f64::consts::FRAC_PI_2).abs() < 1e-6);
+        assert!((o.altitude as f64 - 0.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn half_x_tilt_fraction_has_sixty_degree_altitude() {
+        let o = orientation_from_tilt_fraction(0.5, 0.0);
+        assert!((o.azimuth as f64 - 0.0).abs() < 1e-6);
+        assert!((o.altitude as f64 - core::f64::consts::FRAC_PI_3).abs() < 1e-6);
+    }
+
+    #[test]
+    fn non_finite_tilt_fraction_defaults_to_perpendicular() {
+        let o = orientation_from_tilt_fraction(f64::NAN, f64::INFINITY);
+        assert!((o.altitude as f64 - core::f64::consts::FRAC_PI_2).abs() < 1e-6);
+        assert!((o.azimuth as f64 - core::f64::consts::FRAC_PI_2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn platform_pointer_ids_do_not_collide_with_primary() {
+        let pointer = pointer_info_from_platform_ids(PointerType::Pen, Some(0), Some(0));
+        assert_ne!(pointer.pointer_id, Some(PointerId::PRIMARY));
+        assert!(!pointer.is_primary_pointer());
+    }
+}

--- a/ui-events-apple-common/CHANGELOG.md
+++ b/ui-events-apple-common/CHANGELOG.md
@@ -1,0 +1,23 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+UI Events Apple Common has not yet been published.
+
+## [Unreleased]
+
+This release has an [MSRV][] of 1.85.
+
+### Added
+
+- Shared `no_std` mapping helpers for the AppKit and UIKit adapters.
+
+[Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/ui-events-apple-common/Cargo.toml
+++ b/ui-events-apple-common/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ui-events-apple-common"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Shared Apple adapter mapping helpers for ui-events"
+keywords = ["apple", "input", "ui-events"]
+categories = ["gui"]
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.docs.rs]
+all-features = true
+
+[features]
+default = ["std"]
+libm = []
+std = ["ui-events/std", "dpi/std"]
+
+[dependencies]
+ui-events.workspace = true
+dpi.workspace = true
+
+[lints]
+workspace = true

--- a/ui-events-apple-common/LICENSE-APACHE
+++ b/ui-events-apple-common/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/ui-events-apple-common/LICENSE-MIT
+++ b/ui-events-apple-common/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ui-events-apple-common/README.md
+++ b/ui-events-apple-common/README.md
@@ -1,0 +1,107 @@
+<div align="center">
+
+# UI Events Apple Common
+
+Shared `no_std` mapping helpers used by the AppKit and UIKit adapters.
+
+[![Linebender Zulip, #general channel](https://img.shields.io/badge/Linebender-%23general-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/147921-general)
+[![dependency status](https://deps.rs/repo/github/endoli/ui-events/status.svg)](https://deps.rs/repo/github/endoli/ui-events)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+[![Build status](https://github.com/endoli/ui-events/workflows/CI/badge.svg)](https://github.com/endoli/ui-events/actions)
+[![Crates.io](https://img.shields.io/crates/v/ui-events-apple-common.svg)](https://crates.io/crates/ui-events-apple-common)
+[![Docs](https://docs.rs/ui-events-apple-common/badge.svg)](https://docs.rs/ui-events-apple-common)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=ui-events-apple-common --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
+[`ui-events`]: https://docs.rs/ui-events/
+<!-- cargo-rdme start -->
+
+Shared `no_std` mapping helpers for Apple platform adapters.
+
+This crate owns platform-neutral construction of raw [`ui-events`] building
+blocks from values extracted by the AppKit and UIKit adapter crates. It
+intentionally does not depend on AppKit, UIKit, or `objc2`, and it does not
+decide which platform callbacks should become which high-level events.
+
+## Feature Policy
+
+- `std` is enabled by default.
+- `libm` is accepted as a no-op compatibility feature for the workspace
+  `no_std` check matrix.
+
+## Helper Groups
+
+- Pointer identity helpers reserve [`PointerId::PRIMARY`] and map platform
+  ids through [`PLATFORM_POINTER_ID_OFFSET`].
+- Button helpers translate platform button indexes and bitmasks into
+  [`PointerButton`] and [`PointerButtons`].
+- Modifier helpers build [`Modifiers`] from platform modifier bits.
+- State helpers build [`PointerState`] and [`ScrollDelta`] from finite raw
+  values already extracted by an adapter crate.
+
+These helpers are intentionally small and value-based. AppKit and UIKit
+crates still own all Objective-C selector access and platform-specific event
+routing.
+
+[`Modifiers`]: ui_events::keyboard::Modifiers
+[`PointerButton`]: ui_events::pointer::PointerButton
+[`PointerButtons`]: ui_events::pointer::PointerButtons
+[`PointerId::PRIMARY`]: ui_events::pointer::PointerId::PRIMARY
+[`PointerState`]: ui_events::pointer::PointerState
+[`ScrollDelta`]: ui_events::ScrollDelta
+[`ui-events`]: https://docs.rs/ui-events/
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This version of UI Events Apple Common has been verified to compile with **Rust 1.85** and later.
+
+Future versions of UI Events Apple Common might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some UI Events Apple Common dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
+## Community
+
+[![Linebender Zulip](https://img.shields.io/badge/Xi%20Zulip-%23general-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/147921-general)
+
+Discussion of UI Events Apple Common development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#general channel](https://xi.zulipchat.com/#narrow/channel/147921-general).
+All public content can be read without logging in.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ./AUTHORS

--- a/ui-events-apple-common/src/buttons.rs
+++ b/ui-events-apple-common/src/buttons.rs
@@ -1,0 +1,73 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use ui_events::pointer::{PointerButton, PointerButtons};
+
+/// Map a platform button index to a [`PointerButton`].
+///
+/// Common mapping: 0=Primary (left), 1=Secondary (right), 2=Auxiliary
+/// (middle), 3=X1, 4=X2; higher indices map to B7..B32 when possible.
+pub fn try_from_button_index(i: i64) -> Option<PointerButton> {
+    Some(match i {
+        0 => PointerButton::Primary,
+        1 => PointerButton::Secondary,
+        2 => PointerButton::Auxiliary,
+        3 => PointerButton::X1,
+        4 => PointerButton::X2,
+        5 => PointerButton::PenEraser,
+        6 => PointerButton::B7,
+        7 => PointerButton::B8,
+        8 => PointerButton::B9,
+        9 => PointerButton::B10,
+        10 => PointerButton::B11,
+        11 => PointerButton::B12,
+        12 => PointerButton::B13,
+        13 => PointerButton::B14,
+        14 => PointerButton::B15,
+        15 => PointerButton::B16,
+        16 => PointerButton::B17,
+        17 => PointerButton::B18,
+        18 => PointerButton::B19,
+        19 => PointerButton::B20,
+        20 => PointerButton::B21,
+        21 => PointerButton::B22,
+        22 => PointerButton::B23,
+        23 => PointerButton::B24,
+        24 => PointerButton::B25,
+        25 => PointerButton::B26,
+        26 => PointerButton::B27,
+        27 => PointerButton::B28,
+        28 => PointerButton::B29,
+        29 => PointerButton::B30,
+        30 => PointerButton::B31,
+        31 => PointerButton::B32,
+        _ => return None,
+    })
+}
+
+/// Convert a bitmask of pressed buttons (LSB = button 0) into
+/// [`PointerButtons`].
+pub fn buttons_from_bitmask(mask: u64) -> PointerButtons {
+    let mut out = PointerButtons::default();
+    for idx in 0..32 {
+        if (mask & (1_u64 << idx)) != 0 {
+            if let Some(b) = try_from_button_index(idx as i64) {
+                out.insert(b);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buttons_from_bitmask_maps_common_buttons() {
+        let buttons = buttons_from_bitmask((1 << 0) | (1 << 1) | (1 << 4));
+        assert!(buttons.contains(PointerButton::Primary));
+        assert!(buttons.contains(PointerButton::Secondary));
+        assert!(buttons.contains(PointerButton::X2));
+    }
+}

--- a/ui-events-apple-common/src/identity.rs
+++ b/ui-events-apple-common/src/identity.rs
@@ -1,0 +1,93 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use ui_events::pointer::{PersistentDeviceId, PointerId, PointerInfo, PointerType};
+
+/// Offset applied to platform pointer identifiers before constructing
+/// [`PointerId`] or [`PersistentDeviceId`] values.
+///
+/// `ui-events` reserves [`PointerId::PRIMARY`] with the underlying value `1`.
+/// Offsetting platform id `0` by `2` makes the first platform-derived id `2`,
+/// avoiding collisions with the synthetic primary pointer id.
+pub const PLATFORM_POINTER_ID_OFFSET: u64 = 2;
+
+/// Build a [`PointerInfo`] from a platform pointer identifier.
+pub fn pointer_info_from_platform_pointer_id(
+    pointer_type: PointerType,
+    pointer_id: u64,
+) -> PointerInfo {
+    let pointer_id = pointer_id
+        .checked_add(PLATFORM_POINTER_ID_OFFSET)
+        .and_then(PointerId::new);
+    PointerInfo {
+        pointer_id,
+        persistent_device_id: None,
+        pointer_type,
+    }
+}
+
+/// Build a [`PointerInfo`] from platform pointer and device identifiers.
+pub fn pointer_info_from_platform_ids(
+    pointer_type: PointerType,
+    pointer_id: Option<u64>,
+    device_id: Option<u64>,
+) -> PointerInfo {
+    let pointer_id = pointer_id
+        .and_then(|id| id.checked_add(PLATFORM_POINTER_ID_OFFSET))
+        .and_then(PointerId::new);
+    let persistent_device_id = device_id
+        .and_then(|id| id.checked_add(PLATFORM_POINTER_ID_OFFSET))
+        .and_then(PersistentDeviceId::new);
+    PointerInfo {
+        pointer_id,
+        persistent_device_id,
+        pointer_type,
+    }
+}
+
+/// Build a [`PointerInfo`] for the given [`PointerType`] with a primary id.
+pub fn pointer_info_primary_for_type(pointer_type: PointerType) -> PointerInfo {
+    PointerInfo {
+        pointer_id: Some(PointerId::PRIMARY),
+        persistent_device_id: None,
+        pointer_type,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn platform_pointer_id_zero_does_not_collide_with_primary() {
+        let pointer = pointer_info_from_platform_pointer_id(PointerType::Pen, 0);
+        assert_eq!(
+            pointer
+                .pointer_id
+                .expect("platform ids should be assigned")
+                .get_inner()
+                .get(),
+            PLATFORM_POINTER_ID_OFFSET
+        );
+        assert_ne!(pointer.pointer_id, Some(PointerId::PRIMARY));
+        assert!(!pointer.is_primary_pointer());
+    }
+
+    #[test]
+    fn platform_pointer_and_device_ids_zero_do_not_collide_with_primary() {
+        let pointer = pointer_info_from_platform_ids(PointerType::Pen, Some(0), Some(0));
+        assert_eq!(
+            pointer
+                .pointer_id
+                .expect("platform ids should be assigned")
+                .get_inner()
+                .get(),
+            PLATFORM_POINTER_ID_OFFSET
+        );
+        assert_eq!(
+            pointer.persistent_device_id,
+            PersistentDeviceId::new(PLATFORM_POINTER_ID_OFFSET)
+        );
+        assert_ne!(pointer.pointer_id, Some(PointerId::PRIMARY));
+    }
+}

--- a/ui-events-apple-common/src/lib.rs
+++ b/ui-events-apple-common/src/lib.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Shared `no_std` mapping helpers for Apple platform adapters.
+//!
+//! This crate owns platform-neutral construction of raw [`ui-events`] building
+//! blocks from values extracted by the AppKit and UIKit adapter crates. It
+//! intentionally does not depend on AppKit, UIKit, or `objc2`, and it does not
+//! decide which platform callbacks should become which high-level events.
+//!
+//! ## Feature Policy
+//!
+//! - `std` is enabled by default.
+//! - `libm` is accepted as a no-op compatibility feature for the workspace
+//!   `no_std` check matrix.
+//!
+//! ## Helper Groups
+//!
+//! - Pointer identity helpers reserve [`PointerId::PRIMARY`] and map platform
+//!   ids through [`PLATFORM_POINTER_ID_OFFSET`].
+//! - Button helpers translate platform button indexes and bitmasks into
+//!   [`PointerButton`] and [`PointerButtons`].
+//! - Modifier helpers build [`Modifiers`] from platform modifier bits.
+//! - State helpers build [`PointerState`] and [`ScrollDelta`] from finite raw
+//!   values already extracted by an adapter crate.
+//!
+//! These helpers are intentionally small and value-based. AppKit and UIKit
+//! crates still own all Objective-C selector access and platform-specific event
+//! routing.
+//!
+//! [`Modifiers`]: ui_events::keyboard::Modifiers
+//! [`PointerButton`]: ui_events::pointer::PointerButton
+//! [`PointerButtons`]: ui_events::pointer::PointerButtons
+//! [`PointerId::PRIMARY`]: ui_events::pointer::PointerId::PRIMARY
+//! [`PointerState`]: ui_events::pointer::PointerState
+//! [`ScrollDelta`]: ui_events::ScrollDelta
+//! [`ui-events`]: https://docs.rs/ui-events/
+
+#![no_std]
+
+mod buttons;
+mod identity;
+mod modifiers;
+mod state;
+
+pub use buttons::{buttons_from_bitmask, try_from_button_index};
+pub use identity::{
+    PLATFORM_POINTER_ID_OFFSET, pointer_info_from_platform_ids,
+    pointer_info_from_platform_pointer_id, pointer_info_primary_for_type,
+};
+pub use modifiers::modifiers_from_bools;
+pub use state::{pointer_scroll_delta_from_raw, pointer_state_from_raw};

--- a/ui-events-apple-common/src/modifiers.rs
+++ b/ui-events-apple-common/src/modifiers.rs
@@ -1,0 +1,36 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use ui_events::keyboard::Modifiers;
+
+/// Build a [`Modifiers`] from booleans.
+pub fn modifiers_from_bools(ctrl: bool, alt: bool, shift: bool, meta: bool) -> Modifiers {
+    let mut m = Modifiers::default();
+    if ctrl {
+        m.insert(Modifiers::CONTROL);
+    }
+    if alt {
+        m.insert(Modifiers::ALT);
+    }
+    if shift {
+        m.insert(Modifiers::SHIFT);
+    }
+    if meta {
+        m.insert(Modifiers::META);
+    }
+    m
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn modifiers_from_bools_sets_expected_bits() {
+        let mods = modifiers_from_bools(true, true, true, true);
+        assert!(mods.ctrl());
+        assert!(mods.alt());
+        assert!(mods.shift());
+        assert!(mods.meta());
+    }
+}

--- a/ui-events-apple-common/src/state.rs
+++ b/ui-events-apple-common/src/state.rs
@@ -1,0 +1,196 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use dpi::{PhysicalPosition, PhysicalSize};
+use ui_events::ScrollDelta;
+use ui_events::pointer::PointerState;
+
+use crate::{buttons_from_bitmask, modifiers_from_bools};
+
+/// Build a [`PointerState`] from raw values.
+///
+/// Positions in points are converted to physical pixels by `scale_factor`.
+/// `timestamp_secs` is the platform monotonic timebase in fractional seconds
+/// since boot, not Unix epoch time.
+/// Non-finite scalar inputs are sanitized to conservative defaults before
+/// constructing the event state.
+pub fn pointer_state_from_raw(
+    x_points: f64,
+    y_points: f64,
+    scale_factor: f64,
+    buttons_mask: u64,
+    ctrl: bool,
+    alt: bool,
+    shift: bool,
+    meta: bool,
+    pressure: Option<f64>,
+    tangential_pressure: Option<f64>,
+    contact_w_points: Option<f64>,
+    contact_h_points: Option<f64>,
+    timestamp_secs: f64,
+    click_count: i64,
+) -> PointerState {
+    let scale_factor = positive_finite_or(scale_factor, 1.0);
+    let x_points = finite_or(x_points, 0.0);
+    let y_points = finite_or(y_points, 0.0);
+    let position = PhysicalPosition {
+        x: x_points * scale_factor,
+        y: y_points * scale_factor,
+    };
+    let buttons = buttons_from_bitmask(buttons_mask);
+    let default_pressure = if buttons.is_empty() { 0.0 } else { 0.5 };
+    let pressure = f64_to_f32(finite_option_or(pressure, default_pressure));
+    let tangential_pressure = f64_to_f32(finite_option_or(tangential_pressure, 0.0));
+    let contact_geometry = PhysicalSize {
+        width: non_negative_finite_option_or(contact_w_points, 1.0) * scale_factor,
+        height: non_negative_finite_option_or(contact_h_points, 1.0) * scale_factor,
+    };
+    PointerState {
+        time: secs_to_ns_u64(timestamp_secs),
+        position,
+        buttons,
+        modifiers: modifiers_from_bools(ctrl, alt, shift, meta),
+        count: (click_count.clamp(0, 255)) as u8,
+        contact_geometry,
+        orientation: Default::default(),
+        pressure,
+        tangential_pressure,
+        scale_factor,
+    }
+}
+
+/// Build a [`ScrollDelta`] from deltas in points.
+///
+/// When `precise` is true, deltas are interpreted as pixel deltas and mapped
+/// to [`ScrollDelta::PixelDelta`]. Otherwise they are interpreted as line
+/// deltas and mapped to [`ScrollDelta::LineDelta`]. Delta signs are preserved.
+pub fn pointer_scroll_delta_from_raw(
+    scale_factor: f64,
+    precise: bool,
+    delta_x_points: f64,
+    delta_y_points: f64,
+) -> ScrollDelta {
+    let scale_factor = positive_finite_or(scale_factor, 1.0);
+    let delta_x_points = finite_or(delta_x_points, 0.0);
+    let delta_y_points = finite_or(delta_y_points, 0.0);
+    if precise {
+        ScrollDelta::PixelDelta(PhysicalPosition {
+            x: delta_x_points * scale_factor,
+            y: delta_y_points * scale_factor,
+        })
+    } else {
+        ScrollDelta::LineDelta(f64_to_f32(delta_x_points), f64_to_f32(delta_y_points))
+    }
+}
+
+#[inline]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Converting fractional seconds (f64) to integer ns intentionally"
+)]
+fn secs_to_ns_u64(secs: f64) -> u64 {
+    let nanos = finite_or(secs, 0.0) * 1_000_000_000.0;
+    if nanos <= 0.0 {
+        0
+    } else if nanos >= u64::MAX as f64 {
+        u64::MAX
+    } else {
+        nanos as u64
+    }
+}
+
+#[inline]
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Platform deltas/pressure are f64; ui-events stores f32"
+)]
+fn f64_to_f32(v: f64) -> f32 {
+    v as f32
+}
+
+#[inline]
+fn finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() { value } else { fallback }
+}
+
+#[inline]
+fn positive_finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() && value > 0.0 {
+        value
+    } else {
+        fallback
+    }
+}
+
+#[inline]
+fn finite_option_or(value: Option<f64>, fallback: f64) -> f64 {
+    value.filter(|value| value.is_finite()).unwrap_or(fallback)
+}
+
+#[inline]
+fn non_negative_finite_option_or(value: Option<f64>, fallback: f64) -> f64 {
+    value
+        .filter(|value| value.is_finite() && *value >= 0.0)
+        .unwrap_or(fallback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pointer_state_from_raw_sanitizes_non_finite_scalars() {
+        let state = pointer_state_from_raw(
+            f64::NAN,
+            f64::INFINITY,
+            f64::INFINITY,
+            1,
+            false,
+            false,
+            false,
+            false,
+            Some(f64::NAN),
+            Some(f64::NEG_INFINITY),
+            Some(f64::NAN),
+            Some(-1.0),
+            f64::NAN,
+            1,
+        );
+
+        assert_eq!(state.position.x, 0.0);
+        assert_eq!(state.position.y, 0.0);
+        assert_eq!(state.scale_factor, 1.0);
+        assert_eq!(state.pressure, 0.5);
+        assert_eq!(state.tangential_pressure, 0.0);
+        assert_eq!(state.contact_geometry.width, 1.0);
+        assert_eq!(state.contact_geometry.height, 1.0);
+        assert_eq!(state.time, 0);
+    }
+
+    #[test]
+    fn pointer_scroll_delta_from_raw_sanitizes_non_finite_deltas() {
+        let delta = pointer_scroll_delta_from_raw(2.0, true, f64::NAN, f64::INFINITY);
+
+        assert_eq!(
+            delta,
+            ScrollDelta::PixelDelta(PhysicalPosition { x: 0.0, y: 0.0 })
+        );
+    }
+
+    #[test]
+    fn pointer_scroll_delta_from_raw_preserves_precise_delta_signs() {
+        let delta = pointer_scroll_delta_from_raw(2.0, true, 3.0, -4.0);
+
+        assert_eq!(
+            delta,
+            ScrollDelta::PixelDelta(PhysicalPosition { x: 6.0, y: -8.0 })
+        );
+    }
+
+    #[test]
+    fn pointer_scroll_delta_from_raw_preserves_line_delta_signs() {
+        let delta = pointer_scroll_delta_from_raw(2.0, false, 3.0, -4.0);
+
+        assert_eq!(delta, ScrollDelta::LineDelta(3.0, -4.0));
+    }
+}

--- a/ui-events-uikit/CHANGELOG.md
+++ b/ui-events-uikit/CHANGELOG.md
@@ -1,0 +1,24 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+UI Events UIKit has not yet been published.
+
+## [Unreleased]
+
+This release has an [MSRV][] of 1.85.
+
+### Added
+
+- UIKit touch, remote, and keyboard adapter helpers.
+- `UIKitInputResponder`, a reusable `UIResponder` for touch, remote, and keyboard input.
+
+[Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/ui-events-uikit/Cargo.toml
+++ b/ui-events-uikit/Cargo.toml
@@ -1,0 +1,62 @@
+[package]
+name = "ui-events-uikit"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Bridges UIKit (iOS/tvOS) events into ui-events via objc2"
+keywords = ["apple", "ios", "uikit", "objc2", "input"]
+categories = ["gui"]
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "aarch64-apple-ios"
+targets = []
+
+[features]
+default = ["std"]
+libm = ["dep:libm"]
+std = ["ui-events/std", "ui-events-apple-common/std", "dpi/std"]
+gestures = [
+    "objc2-ui-kit/UIGestureRecognizer",
+    "objc2-ui-kit/UIPinchGestureRecognizer",
+    "objc2-ui-kit/UIRotationGestureRecognizer",
+]
+
+[dependencies]
+ui-events.workspace = true
+ui-events-apple-common.workspace = true
+dpi.workspace = true
+libm = { version = "0.2.15", optional = true, default-features = false }
+
+[target.'cfg(any(target_os = "ios", target_os = "tvos"))'.dependencies]
+objc2 = { version = "0.6.2", default-features = false, features = ["std"] }
+objc2-core-foundation = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "CFCGTypes",
+    "objc2",
+] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "NSArray",
+    "NSEnumerator",
+    "NSSet",
+] }
+objc2-ui-kit = { version = "0.3.2", default-features = false, features = [
+    "std",
+    "UICommand",
+    "UIEvent",
+    "UIPress",
+    "UIPressesEvent",
+    "UIResponder",
+    "UITouch",
+    "UIView",
+    "UIKey",
+    "UIKeyConstants",
+    "objc2-core-foundation",
+] }
+
+[lints]
+workspace = true

--- a/ui-events-uikit/LICENSE-APACHE
+++ b/ui-events-uikit/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/ui-events-uikit/LICENSE-MIT
+++ b/ui-events-uikit/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ui-events-uikit/README.md
+++ b/ui-events-uikit/README.md
@@ -1,0 +1,149 @@
+<div align="center">
+
+# UI Events UIKit Adapter
+
+A library for bridging UIKit events into the `ui-events` model.
+
+[![Linebender Zulip, #general channel](https://img.shields.io/badge/Linebender-%23general-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/147921-general)
+[![dependency status](https://deps.rs/repo/github/endoli/ui-events/status.svg)](https://deps.rs/repo/github/endoli/ui-events)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+[![Build status](https://github.com/endoli/ui-events/workflows/CI/badge.svg)](https://github.com/endoli/ui-events/actions)
+[![Crates.io](https://img.shields.io/crates/v/ui-events-uikit.svg)](https://crates.io/crates/ui-events-uikit)
+[![Docs](https://docs.rs/ui-events-uikit/badge.svg)](https://docs.rs/ui-events-uikit)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=ui-events-uikit --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
+[`ui-events`]: https://docs.rs/ui-events/
+<!-- cargo-rdme start -->
+
+UIKit (iOS/tvOS) adapter using `objc2`.
+
+This crate provides lightweight helpers to convert UIKit events into
+[`ui-events`] types, mirroring the style of the `ui-events-web` and
+`ui-events-winit` adapters.
+
+It does not provide a `UIView` implementation for you. Instead, your
+`UIView` or responder should call these helpers from the corresponding
+UIKit callbacks, or install `UIKitInputResponder` as a reusable responder
+for touch, remote, and keyboard input.
+
+Currently supported:
+
+- Pointer (touch/stylus) down/up/move/cancel
+- Pencil hover enter/move/leave when UIKit reports region phases
+- tvOS remote presses → keyboard
+- Hardware keyboard via `UIPress` + `UIKey`
+- `UIKitInputResponder`, a reusable `UIResponder` for touch, remote, and
+  keyboard input
+
+## Feature Policy
+
+- `std` is enabled by default and uses the platform math intrinsics.
+- `libm` is required for `no_std` builds because stylus pressure normalization uses `sin`.
+- The crate is `no_std` with `alloc` when default features are disabled.
+  The `objc2*` crates are still compiled with their `std` feature enabled on
+  Apple mobile targets to support Objective-C runtime integration.
+- Defaults avoid pulling in unnecessary APIs by disabling default features
+  for `objc2*` crates and enabling only the UIKit symbols this crate uses.
+
+## Pointer Notes
+
+- Touch positions come from `UITouch::preciseLocationInView(None)`, scaled
+  from points into physical pixels. The caller chooses the view coordinate
+  space by passing the view to UIKit before using lower-level mappers.
+- Touch timestamps use UIKit's monotonic seconds-since-boot timebase, not
+  Unix epoch time.
+- Touch pressure is derived from `UITouch.force/maximumPossibleForce` when available.
+- Stylus (Apple Pencil) pressure is converted from force along the stylus axis to
+  perpendicular-to-surface pressure using `sin(altitudeAngle)`.
+- Stylus orientation is mapped from `altitudeAngle`/`azimuthAngleInView`.
+- Pencil hover maps to enter/move/leave when UIKit reports `RegionEntered`,
+  `RegionMoved`, and `RegionExited`.
+- Finger touches use `button: None`, matching the DOM `TouchEvent` path in
+  `ui-events-web`. Active stylus contacts use [`PointerButton::Primary`](ui_events::pointer::PointerButton::Primary).
+- UIKit exposes stylus `rollAngle`, but `ui-events` currently has no roll field.
+- UIKit exposes estimated-property update APIs, but `ui-events` currently has no sample-revision
+  metadata for correcting previously emitted stylus samples.
+- UIKit does not expose a tangential-pressure value on `UITouch`, so
+  [`PointerState::tangential_pressure`](ui_events::pointer::PointerState::tangential_pressure)
+  remains `0.0` for this adapter.
+
+## Gestures
+
+- Pinch gesture recognizers map to [`PointerGesture::Pinch`](ui_events::pointer::PointerGesture::Pinch)
+  by differencing UIKit's cumulative `scale` against a caller-provided
+  previous scale. Rotation gesture recognizers follow the same pattern with
+  cumulative counterclockwise `rotation` values.
+
+## High-Level Helpers
+
+- `UIKitInputResponder`
+- `keyboard_event_from_uipress`
+- `keyboard_event_from_uikey`
+- `pointer_event_from_touch_and_event`
+- `pointer_event_from_touch` (uncommon convenience helper)
+- `pointer_gesture_from_uipinch` (feature: `gestures`)
+- `pointer_gesture_from_uirotation` (feature: `gestures`)
+- `mapping::pinch_delta_from_cumulative_scale` (feature: `gestures`)
+- `mapping::rotation_delta_from_cumulative_rotation` (feature: `gestures`)
+
+If you prefer, low-level mappers in [`mapping`] let you build events from
+raw values (e.g. coordinates, button number, modifier booleans) without
+pulling in UIKit types in your own code.
+
+[`ui-events`]: https://docs.rs/ui-events/
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This version of UI Events UIKit has been verified to compile with **Rust 1.85** and later.
+
+Future versions of UI Events UIKit might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some UI Events UIKit dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
+## Community
+
+[![Linebender Zulip](https://img.shields.io/badge/Xi%20Zulip-%23general-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/147921-general)
+
+Discussion of UI Events UIKit development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#general channel](https://xi.zulipchat.com/#narrow/channel/147921-general).
+All public content can be read without logging in.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ./AUTHORS

--- a/ui-events-uikit/src/input_responder.rs
+++ b/ui-events-uikit/src/input_responder.rs
@@ -1,0 +1,149 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Reusable UIKit responder for touch, remote, and keyboard input.
+
+use alloc::boxed::Box;
+
+use objc2::rc::Retained;
+use objc2::{DefinedClass, MainThreadMarker, MainThreadOnly, define_class, msg_send};
+use objc2_foundation::NSSet;
+use objc2_ui_kit::{UIEvent, UIKey, UIPress, UIPressesEvent, UIResponder, UITouch};
+use ui_events::keyboard::KeyboardEvent;
+use ui_events::pointer::PointerEvent;
+
+use crate::{
+    keyboard_event_from_uikey, keyboard_event_from_uipress, pointer_event_from_touch,
+    pointer_event_from_touch_and_event,
+};
+
+/// Host-side event sink for [`UIKitInputResponder`].
+pub trait UIKitInputResponderHost {
+    /// Handle a translated UIKit keyboard or remote-button event.
+    fn handle_keyboard_event(&self, event: KeyboardEvent);
+
+    /// Handle a translated UIKit touch or stylus pointer event.
+    fn handle_pointer_event(&self, event: PointerEvent);
+
+    /// Return the scale factor used when converting UIKit pointer positions
+    /// from logical points into physical pixels.
+    fn pointer_scale_factor(&self) -> f64;
+}
+
+#[doc(hidden)]
+pub struct InputResponderState {
+    host: Box<dyn UIKitInputResponderHost>,
+}
+
+impl core::fmt::Debug for InputResponderState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("InputResponderState")
+            .field("host", &"<dyn UIKitInputResponderHost>")
+            .finish()
+    }
+}
+
+define_class!(
+    #[unsafe(super = UIResponder)]
+    #[thread_kind = objc2::MainThreadOnly]
+    #[name = "UIEventsUIKitInputResponder"]
+    #[ivars = InputResponderState]
+    #[doc = "Reusable UIKit responder for touch, remote, and keyboard input."]
+    pub struct UIKitInputResponder;
+
+    impl UIKitInputResponder {
+        #[unsafe(method(canBecomeFirstResponder))]
+        fn can_become_first_responder(&self) -> bool {
+            true
+        }
+
+        #[unsafe(method(touchesBegan:withEvent:))]
+        fn touches_began(&self, touches: &NSSet<UITouch>, event: Option<&UIEvent>) {
+            self.handle_touch_set(touches, event);
+        }
+
+        #[unsafe(method(touchesMoved:withEvent:))]
+        fn touches_moved(&self, touches: &NSSet<UITouch>, event: Option<&UIEvent>) {
+            self.handle_touch_set(touches, event);
+        }
+
+        #[unsafe(method(touchesEnded:withEvent:))]
+        fn touches_ended(&self, touches: &NSSet<UITouch>, event: Option<&UIEvent>) {
+            self.handle_touch_set(touches, event);
+        }
+
+        #[unsafe(method(touchesCancelled:withEvent:))]
+        fn touches_cancelled(&self, touches: &NSSet<UITouch>, event: Option<&UIEvent>) {
+            self.handle_touch_set(touches, event);
+        }
+
+        #[unsafe(method(pressesBegan:withEvent:))]
+        fn presses_began(&self, presses: &NSSet<UIPress>, _event: Option<&UIPressesEvent>) {
+            self.handle_press_set(presses);
+        }
+
+        #[unsafe(method(pressesChanged:withEvent:))]
+        fn presses_changed(&self, presses: &NSSet<UIPress>, _event: Option<&UIPressesEvent>) {
+            self.handle_press_set(presses);
+        }
+
+        #[unsafe(method(pressesEnded:withEvent:))]
+        fn presses_ended(&self, presses: &NSSet<UIPress>, _event: Option<&UIPressesEvent>) {
+            self.handle_press_set(presses);
+        }
+
+        #[unsafe(method(pressesCancelled:withEvent:))]
+        fn presses_cancelled(&self, presses: &NSSet<UIPress>, _event: Option<&UIPressesEvent>) {
+            self.handle_press_set(presses);
+        }
+    }
+);
+
+impl UIKitInputResponder {
+    /// Create a reusable UIKit responder for touch, remote, and keyboard input.
+    pub fn new(mtm: MainThreadMarker, host: Box<dyn UIKitInputResponderHost>) -> Retained<Self> {
+        let this = Self::alloc(mtm).set_ivars(InputResponderState { host });
+        // SAFETY: `UIResponder` has no additional initialization requirements.
+        unsafe { msg_send![super(this), init] }
+    }
+
+    /// Translate all touches in a UIKit callback and forward them to the host.
+    pub fn handle_touch_set(&self, touches: &NSSet<UITouch>, event: Option<&UIEvent>) {
+        for touch in touches.iter() {
+            self.handle_touch(touch.as_ref(), event);
+        }
+    }
+
+    /// Translate a single `UITouch` and optional `UIEvent`, then forward it to
+    /// the host.
+    pub fn handle_touch(&self, touch: &UITouch, event: Option<&UIEvent>) {
+        let scale_factor = self.ivars().host.pointer_scale_factor();
+        let event = event
+            .and_then(|event| pointer_event_from_touch_and_event(touch, event, scale_factor))
+            .or_else(|| pointer_event_from_touch(touch, scale_factor));
+        if let Some(event) = event {
+            self.ivars().host.handle_pointer_event(event);
+        }
+    }
+
+    /// Translate all presses in a UIKit callback and forward them to the host.
+    pub fn handle_press_set(&self, presses: &NSSet<UIPress>) {
+        let mtm = MainThreadMarker::from(self);
+        for press in presses.iter() {
+            self.handle_press(press.as_ref(), mtm);
+        }
+    }
+
+    /// Translate a single `UIPress`, preferring attached `UIKey` information
+    /// when available, then forward it to the host.
+    pub fn handle_press(&self, press: &UIPress, mtm: MainThreadMarker) {
+        let event = press
+            .key(mtm)
+            .as_deref()
+            .and_then(|key: &UIKey| keyboard_event_from_uikey(press, key))
+            .or_else(|| keyboard_event_from_uipress(press));
+        if let Some(event) = event {
+            self.ivars().host.handle_keyboard_event(event);
+        }
+    }
+}

--- a/ui-events-uikit/src/lib.rs
+++ b/ui-events-uikit/src/lib.rs
@@ -1,0 +1,101 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! UIKit (iOS/tvOS) adapter using `objc2`.
+//!
+//! This crate provides lightweight helpers to convert UIKit events into
+//! [`ui-events`] types, mirroring the style of the `ui-events-web` and
+//! `ui-events-winit` adapters.
+//!
+//! It does not provide a `UIView` implementation for you. Instead, your
+//! `UIView` or responder should call these helpers from the corresponding
+//! UIKit callbacks, or install `UIKitInputResponder` as a reusable responder
+//! for touch, remote, and keyboard input.
+//!
+//! Currently supported:
+//!
+//! - Pointer (touch/stylus) down/up/move/cancel
+//! - Pencil hover enter/move/leave when UIKit reports region phases
+//! - tvOS remote presses → keyboard
+//! - Hardware keyboard via `UIPress` + `UIKey`
+//! - `UIKitInputResponder`, a reusable `UIResponder` for touch, remote, and
+//!   keyboard input
+//!
+//! ## Feature Policy
+//!
+//! - `std` is enabled by default and uses the platform math intrinsics.
+//! - `libm` is required for `no_std` builds because stylus pressure normalization uses `sin`.
+//! - The crate is `no_std` with `alloc` when default features are disabled.
+//!   The `objc2*` crates are still compiled with their `std` feature enabled on
+//!   Apple mobile targets to support Objective-C runtime integration.
+//! - Defaults avoid pulling in unnecessary APIs by disabling default features
+//!   for `objc2*` crates and enabling only the UIKit symbols this crate uses.
+//!
+//! ## Pointer Notes
+//!
+//! - Touch positions come from `UITouch::preciseLocationInView(None)`, scaled
+//!   from points into physical pixels. The caller chooses the view coordinate
+//!   space by passing the view to UIKit before using lower-level mappers.
+//! - Touch timestamps use UIKit's monotonic seconds-since-boot timebase, not
+//!   Unix epoch time.
+//! - Touch pressure is derived from `UITouch.force/maximumPossibleForce` when available.
+//! - Stylus (Apple Pencil) pressure is converted from force along the stylus axis to
+//!   perpendicular-to-surface pressure using `sin(altitudeAngle)`.
+//! - Stylus orientation is mapped from `altitudeAngle`/`azimuthAngleInView`.
+//! - Pencil hover maps to enter/move/leave when UIKit reports `RegionEntered`,
+//!   `RegionMoved`, and `RegionExited`.
+//! - Finger touches use `button: None`, matching the DOM `TouchEvent` path in
+//!   `ui-events-web`. Active stylus contacts use [`PointerButton::Primary`](ui_events::pointer::PointerButton::Primary).
+//! - UIKit exposes stylus `rollAngle`, but `ui-events` currently has no roll field.
+//! - UIKit exposes estimated-property update APIs, but `ui-events` currently has no sample-revision
+//!   metadata for correcting previously emitted stylus samples.
+//! - UIKit does not expose a tangential-pressure value on `UITouch`, so
+//!   [`PointerState::tangential_pressure`](ui_events::pointer::PointerState::tangential_pressure)
+//!   remains `0.0` for this adapter.
+//!
+//! ## Gestures
+//!
+//! - Pinch gesture recognizers map to [`PointerGesture::Pinch`](ui_events::pointer::PointerGesture::Pinch)
+//!   by differencing UIKit's cumulative `scale` against a caller-provided
+//!   previous scale. Rotation gesture recognizers follow the same pattern with
+//!   cumulative counterclockwise `rotation` values.
+//!
+//! ## High-Level Helpers
+//!
+//! - `UIKitInputResponder`
+//! - `keyboard_event_from_uipress`
+//! - `keyboard_event_from_uikey`
+//! - `pointer_event_from_touch_and_event`
+//! - `pointer_event_from_touch` (uncommon convenience helper)
+//! - `pointer_gesture_from_uipinch` (feature: `gestures`)
+//! - `pointer_gesture_from_uirotation` (feature: `gestures`)
+//! - `mapping::pinch_delta_from_cumulative_scale` (feature: `gestures`)
+//! - `mapping::rotation_delta_from_cumulative_rotation` (feature: `gestures`)
+//!
+//! If you prefer, low-level mappers in [`mapping`] let you build events from
+//! raw values (e.g. coordinates, button number, modifier booleans) without
+//! pulling in UIKit types in your own code.
+//!
+//! [`ui-events`]: https://docs.rs/ui-events/
+
+#![allow(unsafe_code, reason = "We access platform libraries using ffi.")]
+#![no_std]
+
+extern crate alloc;
+
+pub mod mapping;
+
+#[cfg(any(target_os = "ios", target_os = "tvos"))]
+pub mod input_responder;
+#[cfg(any(target_os = "ios", target_os = "tvos"))]
+pub mod uikit;
+
+// Top-level re-exports for convenience.
+#[cfg(any(target_os = "ios", target_os = "tvos"))]
+pub use input_responder::{UIKitInputResponder, UIKitInputResponderHost};
+#[cfg(any(target_os = "ios", target_os = "tvos"))]
+pub use uikit::{keyboard_event_from_uikey, keyboard_event_from_uipress};
+#[cfg(any(target_os = "ios", target_os = "tvos"))]
+pub use uikit::{pointer_event_from_touch, pointer_event_from_touch_and_event};
+#[cfg(all(any(target_os = "ios", target_os = "tvos"), feature = "gestures"))]
+pub use uikit::{pointer_gesture_from_uipinch, pointer_gesture_from_uirotation};

--- a/ui-events-uikit/src/mapping.rs
+++ b/ui-events-uikit/src/mapping.rs
@@ -1,0 +1,661 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! UIKit-specific mapping helpers for building `ui-events` from raw values.
+
+use dpi::PhysicalSize;
+use ui_events::keyboard::{Code, Location, Modifiers, NamedKey};
+use ui_events::pointer::{PointerButton, PointerInfo, PointerType};
+pub use ui_events_apple_common::{
+    buttons_from_bitmask, modifiers_from_bools, pointer_info_primary_for_type,
+    pointer_state_from_raw, try_from_button_index,
+};
+
+#[cfg(feature = "std")]
+fn sine(angle: f64) -> f64 {
+    angle.sin()
+}
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+fn sine(angle: f64) -> f64 {
+    libm::sin(angle)
+}
+
+#[cfg(all(not(feature = "std"), not(feature = "libm")))]
+compile_error!("ui-events-uikit requires either the `std` or `libm` feature");
+
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets and by unit tests for UIKit contact geometry"
+)]
+fn contact_geometry_from_points(
+    width_points: Option<f64>,
+    height_points: Option<f64>,
+    scale_factor: f64,
+) -> PhysicalSize<f64> {
+    PhysicalSize {
+        width: width_points.unwrap_or(1.0) * scale_factor,
+        height: height_points.unwrap_or(1.0) * scale_factor,
+    }
+}
+
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets where the UIKit adapter is compiled"
+)]
+pub(crate) fn pointer_info_from_platform_pointer_id(
+    pointer_type: PointerType,
+    pointer_id: u64,
+) -> PointerInfo {
+    ui_events_apple_common::pointer_info_from_platform_pointer_id(pointer_type, pointer_id)
+}
+
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets where the UIKit adapter is compiled"
+)]
+pub(crate) fn contact_buttons_mask_for_uikit_pointer(
+    pointer_type: PointerType,
+    active: bool,
+    event_buttons_mask: u64,
+) -> u64 {
+    let mut buttons_mask = event_buttons_mask;
+    if active && matches!(pointer_type, PointerType::Pen) {
+        buttons_mask |= PointerButton::Primary as u64;
+    }
+    buttons_mask
+}
+
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets where the UIKit adapter is compiled"
+)]
+pub(crate) fn contact_button_for_uikit_pointer(pointer_type: PointerType) -> Option<PointerButton> {
+    matches!(pointer_type, PointerType::Pen).then_some(PointerButton::Primary)
+}
+
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets where the UIKit adapter is compiled"
+)]
+mod hid {
+    pub(super) const A: u16 = 0x04;
+    pub(super) const Z: u16 = 0x1D;
+    pub(super) const DIGIT_1: u16 = 0x1E; // through 0x27 => 0..9
+    pub(super) const DIGIT_0: u16 = 0x27;
+    pub(super) const RETURN: u16 = 0x28;
+    pub(super) const ESCAPE: u16 = 0x29;
+    pub(super) const BACKSPACE: u16 = 0x2A; // Delete (Backspace)
+    pub(super) const TAB: u16 = 0x2B;
+    pub(super) const SPACE: u16 = 0x2C;
+    pub(super) const MINUS: u16 = 0x2D;
+    pub(super) const EQUAL: u16 = 0x2E;
+    pub(super) const BRACKET_LEFT: u16 = 0x2F;
+    pub(super) const BRACKET_RIGHT: u16 = 0x30;
+    pub(super) const BACKSLASH: u16 = 0x31;
+    pub(super) const SEMICOLON: u16 = 0x33;
+    pub(super) const QUOTE: u16 = 0x34;
+    pub(super) const GRAVE: u16 = 0x35;
+    pub(super) const COMMA: u16 = 0x36;
+    pub(super) const PERIOD: u16 = 0x37;
+    pub(super) const SLASH: u16 = 0x38;
+    pub(super) const CAPS_LOCK: u16 = 0x39;
+    pub(super) const F1: u16 = 0x3A; // through F12: 0x45
+    pub(super) const F12: u16 = 0x45;
+    pub(super) const F13: u16 = 0x68; // through F24: 0x73
+    pub(super) const F24: u16 = 0x73;
+    pub(super) const PRINT_SCREEN: u16 = 0x46;
+    pub(super) const SCROLL_LOCK: u16 = 0x47;
+    pub(super) const PAUSE: u16 = 0x48;
+    pub(super) const INSERT: u16 = 0x49;
+    pub(super) const HOME: u16 = 0x4A;
+    pub(super) const PAGE_UP: u16 = 0x4B;
+    pub(super) const DELETE_FORWARD: u16 = 0x4C;
+    pub(super) const END: u16 = 0x4D;
+    pub(super) const PAGE_DOWN: u16 = 0x4E;
+    pub(super) const RIGHT_ARROW: u16 = 0x4F;
+    pub(super) const LEFT_ARROW: u16 = 0x50;
+    pub(super) const DOWN_ARROW: u16 = 0x51;
+    pub(super) const UP_ARROW: u16 = 0x52;
+    pub(super) const NUM_LOCK: u16 = 0x53;
+    pub(super) const NUMPAD_DIVIDE: u16 = 0x54;
+    pub(super) const NUMPAD_MULTIPLY: u16 = 0x55;
+    pub(super) const NUMPAD_SUBTRACT: u16 = 0x56;
+    pub(super) const NUMPAD_ADD: u16 = 0x57;
+    pub(super) const NUMPAD_ENTER: u16 = 0x58;
+    pub(super) const NUMPAD_1: u16 = 0x59; // ..0x62 = 1..0
+    pub(super) const NUMPAD_0: u16 = 0x62;
+    pub(super) const NUMPAD_DECIMAL: u16 = 0x63;
+    pub(super) const NUMPAD_EQUAL: u16 = 0x67;
+    pub(super) const CONTROL_LEFT: u16 = 0xE0;
+    pub(super) const SHIFT_LEFT: u16 = 0xE1;
+    pub(super) const ALT_LEFT: u16 = 0xE2;
+    pub(super) const META_LEFT: u16 = 0xE3;
+    pub(super) const CONTROL_RIGHT: u16 = 0xE4;
+    pub(super) const SHIFT_RIGHT: u16 = 0xE5;
+    pub(super) const ALT_RIGHT: u16 = 0xE6;
+    pub(super) const META_RIGHT: u16 = 0xE7;
+}
+
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets where the UIKit adapter is compiled"
+)]
+const UIKIT_SHIFT_BIT: u64 = 1 << 17;
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets where the UIKit adapter is compiled"
+)]
+const UIKIT_CONTROL_BIT: u64 = 1 << 18;
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets where the UIKit adapter is compiled"
+)]
+const UIKIT_ALT_BIT: u64 = 1 << 19;
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets where the UIKit adapter is compiled"
+)]
+const UIKIT_META_BIT: u64 = 1 << 20;
+
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets where the UIKit adapter is compiled"
+)]
+pub(crate) fn modifiers_from_uikit_modifier_bits(bits: u64) -> Modifiers {
+    modifiers_from_bools(
+        (bits & UIKIT_CONTROL_BIT) != 0,
+        (bits & UIKIT_ALT_BIT) != 0,
+        (bits & UIKIT_SHIFT_BIT) != 0,
+        (bits & UIKIT_META_BIT) != 0,
+    )
+}
+
+#[allow(
+    dead_code,
+    reason = "Used on iOS/tvOS targets where the UIKit adapter is compiled"
+)]
+pub(crate) fn hid_usage_to_code_named_location(usage: u16) -> (Code, Option<NamedKey>, Location) {
+    use hid as H;
+    if (H::A..=H::Z).contains(&usage) {
+        let code = match usage - H::A {
+            0 => Code::KeyA,
+            1 => Code::KeyB,
+            2 => Code::KeyC,
+            3 => Code::KeyD,
+            4 => Code::KeyE,
+            5 => Code::KeyF,
+            6 => Code::KeyG,
+            7 => Code::KeyH,
+            8 => Code::KeyI,
+            9 => Code::KeyJ,
+            10 => Code::KeyK,
+            11 => Code::KeyL,
+            12 => Code::KeyM,
+            13 => Code::KeyN,
+            14 => Code::KeyO,
+            15 => Code::KeyP,
+            16 => Code::KeyQ,
+            17 => Code::KeyR,
+            18 => Code::KeyS,
+            19 => Code::KeyT,
+            20 => Code::KeyU,
+            21 => Code::KeyV,
+            22 => Code::KeyW,
+            23 => Code::KeyX,
+            24 => Code::KeyY,
+            _ => Code::KeyZ,
+        };
+        return (code, None, Location::Standard);
+    }
+
+    if (H::DIGIT_1..=H::DIGIT_0).contains(&usage) {
+        let code = match usage {
+            0x1E => Code::Digit1,
+            0x1F => Code::Digit2,
+            0x20 => Code::Digit3,
+            0x21 => Code::Digit4,
+            0x22 => Code::Digit5,
+            0x23 => Code::Digit6,
+            0x24 => Code::Digit7,
+            0x25 => Code::Digit8,
+            0x26 => Code::Digit9,
+            _ => Code::Digit0,
+        };
+        return (code, None, Location::Standard);
+    }
+
+    if (H::NUMPAD_1..=H::NUMPAD_0).contains(&usage) {
+        let code = match usage {
+            0x59 => Code::Numpad1,
+            0x5A => Code::Numpad2,
+            0x5B => Code::Numpad3,
+            0x5C => Code::Numpad4,
+            0x5D => Code::Numpad5,
+            0x5E => Code::Numpad6,
+            0x5F => Code::Numpad7,
+            0x60 => Code::Numpad8,
+            0x61 => Code::Numpad9,
+            _ => Code::Numpad0,
+        };
+        return (code, None, Location::Numpad);
+    }
+
+    match usage {
+        H::RETURN => (Code::Enter, Some(NamedKey::Enter), Location::Standard),
+        H::ESCAPE => (Code::Escape, Some(NamedKey::Escape), Location::Standard),
+        H::BACKSPACE => (
+            Code::Backspace,
+            Some(NamedKey::Backspace),
+            Location::Standard,
+        ),
+        H::TAB => (Code::Tab, Some(NamedKey::Tab), Location::Standard),
+        H::SPACE => (Code::Space, None, Location::Standard),
+        H::MINUS => (Code::Minus, None, Location::Standard),
+        H::EQUAL => (Code::Equal, None, Location::Standard),
+        H::BRACKET_LEFT => (Code::BracketLeft, None, Location::Standard),
+        H::BRACKET_RIGHT => (Code::BracketRight, None, Location::Standard),
+        H::BACKSLASH => (Code::Backslash, None, Location::Standard),
+        H::SEMICOLON => (Code::Semicolon, None, Location::Standard),
+        H::QUOTE => (Code::Quote, None, Location::Standard),
+        H::GRAVE => (Code::Backquote, None, Location::Standard),
+        H::COMMA => (Code::Comma, None, Location::Standard),
+        H::PERIOD => (Code::Period, None, Location::Standard),
+        H::SLASH => (Code::Slash, None, Location::Standard),
+        H::CAPS_LOCK => (Code::CapsLock, Some(NamedKey::CapsLock), Location::Standard),
+        H::F1..=H::F12 => {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "The F-key range is bounded to 1..=12 before narrowing to u8"
+            )]
+            let idx = (usage - H::F1) as u8 + 1;
+            let (code, named) = match idx {
+                1 => (Code::F1, NamedKey::F1),
+                2 => (Code::F2, NamedKey::F2),
+                3 => (Code::F3, NamedKey::F3),
+                4 => (Code::F4, NamedKey::F4),
+                5 => (Code::F5, NamedKey::F5),
+                6 => (Code::F6, NamedKey::F6),
+                7 => (Code::F7, NamedKey::F7),
+                8 => (Code::F8, NamedKey::F8),
+                9 => (Code::F9, NamedKey::F9),
+                10 => (Code::F10, NamedKey::F10),
+                11 => (Code::F11, NamedKey::F11),
+                _ => (Code::F12, NamedKey::F12),
+            };
+            (code, Some(named), Location::Standard)
+        }
+        H::F13..=H::F24 => {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "The F-key range is bounded to 13..=24 before narrowing to u8"
+            )]
+            let idx = (usage - H::F13) as u8 + 13;
+            let (code, named) = match idx {
+                13 => (Code::F13, NamedKey::F13),
+                14 => (Code::F14, NamedKey::F14),
+                15 => (Code::F15, NamedKey::F15),
+                16 => (Code::F16, NamedKey::F16),
+                17 => (Code::F17, NamedKey::F17),
+                18 => (Code::F18, NamedKey::F18),
+                19 => (Code::F19, NamedKey::F19),
+                20 => (Code::F20, NamedKey::F20),
+                21 => (Code::F21, NamedKey::F21),
+                22 => (Code::F22, NamedKey::F22),
+                23 => (Code::F23, NamedKey::F23),
+                _ => (Code::F24, NamedKey::F24),
+            };
+            (code, Some(named), Location::Standard)
+        }
+        H::PRINT_SCREEN => (
+            Code::PrintScreen,
+            Some(NamedKey::PrintScreen),
+            Location::Standard,
+        ),
+        H::SCROLL_LOCK => (
+            Code::ScrollLock,
+            Some(NamedKey::ScrollLock),
+            Location::Standard,
+        ),
+        H::PAUSE => (Code::Pause, Some(NamedKey::Pause), Location::Standard),
+        H::INSERT => (Code::Insert, Some(NamedKey::Insert), Location::Standard),
+        H::HOME => (Code::Home, Some(NamedKey::Home), Location::Standard),
+        H::PAGE_UP => (Code::PageUp, Some(NamedKey::PageUp), Location::Standard),
+        H::DELETE_FORWARD => (Code::Delete, Some(NamedKey::Delete), Location::Standard),
+        H::END => (Code::End, Some(NamedKey::End), Location::Standard),
+        H::PAGE_DOWN => (Code::PageDown, Some(NamedKey::PageDown), Location::Standard),
+        H::RIGHT_ARROW => (
+            Code::ArrowRight,
+            Some(NamedKey::ArrowRight),
+            Location::Standard,
+        ),
+        H::LEFT_ARROW => (
+            Code::ArrowLeft,
+            Some(NamedKey::ArrowLeft),
+            Location::Standard,
+        ),
+        H::DOWN_ARROW => (
+            Code::ArrowDown,
+            Some(NamedKey::ArrowDown),
+            Location::Standard,
+        ),
+        H::UP_ARROW => (Code::ArrowUp, Some(NamedKey::ArrowUp), Location::Standard),
+        H::NUM_LOCK => (Code::NumLock, Some(NamedKey::NumLock), Location::Numpad),
+        H::NUMPAD_DIVIDE => (Code::NumpadDivide, None, Location::Numpad),
+        H::NUMPAD_MULTIPLY => (Code::NumpadMultiply, None, Location::Numpad),
+        H::NUMPAD_SUBTRACT => (Code::NumpadSubtract, None, Location::Numpad),
+        H::NUMPAD_ADD => (Code::NumpadAdd, None, Location::Numpad),
+        H::NUMPAD_ENTER => (Code::NumpadEnter, Some(NamedKey::Enter), Location::Numpad),
+        H::NUMPAD_DECIMAL => (Code::NumpadDecimal, None, Location::Numpad),
+        H::NUMPAD_EQUAL => (Code::NumpadEqual, None, Location::Numpad),
+        H::CONTROL_LEFT => (Code::ControlLeft, Some(NamedKey::Control), Location::Left),
+        H::SHIFT_LEFT => (Code::ShiftLeft, Some(NamedKey::Shift), Location::Left),
+        H::ALT_LEFT => (Code::AltLeft, Some(NamedKey::Alt), Location::Left),
+        H::META_LEFT => (Code::MetaLeft, Some(NamedKey::Meta), Location::Left),
+        H::CONTROL_RIGHT => (Code::ControlRight, Some(NamedKey::Control), Location::Right),
+        H::SHIFT_RIGHT => (Code::ShiftRight, Some(NamedKey::Shift), Location::Right),
+        H::ALT_RIGHT => (Code::AltRight, Some(NamedKey::Alt), Location::Right),
+        H::META_RIGHT => (Code::MetaRight, Some(NamedKey::Meta), Location::Right),
+        _ => (
+            Code::Unidentified,
+            Some(NamedKey::Unidentified),
+            Location::Standard,
+        ),
+    }
+}
+
+/// Convert two cumulative UIKit pinch scales into a `ui-events` pinch delta.
+///
+/// UIKit reports `UIPinchGestureRecognizer::scale` as a cumulative multiplier
+/// since the recognizer began. `ui-events` stores pinch as a per-update scale
+/// delta, so callers must provide the previous cumulative scale.
+///
+/// Returns `None` if either scale is non-finite or non-positive.
+pub fn pinch_delta_from_cumulative_scale(previous_scale: f64, current_scale: f64) -> Option<f32> {
+    if !previous_scale.is_finite()
+        || !current_scale.is_finite()
+        || previous_scale <= 0.0
+        || current_scale <= 0.0
+    {
+        return None;
+    }
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "UIKit gesture values are f64; ui-events uses f32"
+    )]
+    Some((current_scale / previous_scale - 1.0) as f32)
+}
+
+/// Convert two cumulative UIKit rotation values into a `ui-events` rotation
+/// delta.
+///
+/// UIKit reports `UIRotationGestureRecognizer::rotation` as a cumulative
+/// counterclockwise angle in radians since the recognizer began. `ui-events`
+/// stores rotation as a per-update clockwise delta, so callers must provide
+/// the previous cumulative rotation.
+///
+/// Returns `None` if either angle is non-finite.
+pub fn rotation_delta_from_cumulative_rotation(
+    previous_rotation_ccw: f64,
+    current_rotation_ccw: f64,
+) -> Option<f32> {
+    if !previous_rotation_ccw.is_finite() || !current_rotation_ccw.is_finite() {
+        return None;
+    }
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "UIKit gesture values are f64; ui-events uses f32"
+    )]
+    Some((previous_rotation_ccw - current_rotation_ccw) as f32)
+}
+
+/// Derive a normalized touch/stylus pressure in the range 0..=1.
+///
+/// - If `active` is false, returns 0.0.
+/// - If a calibrated force is available (`force_along_axis`, `max_possible_force`), uses
+///   `force/max`, clamped to 0..=1.
+/// - For stylus input, if `altitude_angle` is provided, converts the force along the stylus axis
+///   into a force perpendicular to the surface by multiplying by `sin(altitude_angle)`.
+/// - Otherwise, returns a conservative default of 0.5 for active touches.
+pub fn pressure_from_force(
+    active: bool,
+    force_along_axis: Option<f64>,
+    max_possible_force: Option<f64>,
+    altitude_angle: Option<f64>,
+    is_stylus: bool,
+) -> f64 {
+    if !active {
+        return 0.0;
+    }
+    let Some(force) = force_along_axis else {
+        return 0.5;
+    };
+    let Some(max) = max_possible_force else {
+        return 0.5;
+    };
+    if !force.is_finite() || !max.is_finite() || max <= 0.0 {
+        return 0.5;
+    }
+    let mut p = (force / max).clamp(0.0, 1.0);
+    if is_stylus {
+        if let Some(alt) = altitude_angle {
+            let s = sine(alt);
+            if s.is_finite() {
+                p *= s.clamp(0.0, 1.0);
+            }
+        }
+    }
+    p.clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pressure_inactive_is_zero() {
+        assert_eq!(
+            pressure_from_force(false, Some(1.0), Some(1.0), None, false),
+            0.0
+        );
+    }
+
+    #[test]
+    fn pressure_defaults_when_force_missing() {
+        assert_eq!(pressure_from_force(true, None, None, None, false), 0.5);
+        assert_eq!(pressure_from_force(true, Some(1.0), None, None, false), 0.5);
+        assert_eq!(
+            pressure_from_force(true, Some(1.0), Some(0.0), None, false),
+            0.5
+        );
+        assert_eq!(
+            pressure_from_force(true, Some(1.0), Some(f64::NAN), None, false),
+            0.5
+        );
+    }
+
+    #[test]
+    fn pressure_normalizes_and_clamps() {
+        assert_eq!(
+            pressure_from_force(true, Some(2.0), Some(4.0), None, false),
+            0.5
+        );
+        assert_eq!(
+            pressure_from_force(true, Some(10.0), Some(4.0), None, false),
+            1.0
+        );
+        assert_eq!(
+            pressure_from_force(true, Some(-1.0), Some(4.0), None, false),
+            0.0
+        );
+    }
+
+    #[test]
+    fn stylus_altitude_scales_force_to_perpendicular() {
+        // altitude = pi/2 => sin=1 (no change)
+        let p = pressure_from_force(
+            true,
+            Some(1.0),
+            Some(2.0),
+            Some(core::f64::consts::FRAC_PI_2),
+            true,
+        );
+        assert!((p - 0.5).abs() < 1e-12);
+
+        // altitude = 0 => sin=0 (parallel)
+        let p = pressure_from_force(true, Some(1.0), Some(2.0), Some(0.0), true);
+        assert!((p - 0.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn contact_geometry_defaults_to_single_pixel() {
+        assert_eq!(
+            contact_geometry_from_points(None, None, 2.0),
+            PhysicalSize {
+                width: 2.0,
+                height: 2.0,
+            }
+        );
+    }
+
+    #[test]
+    fn contact_geometry_scales_explicit_points() {
+        assert_eq!(
+            contact_geometry_from_points(Some(3.0), Some(4.0), 1.5),
+            PhysicalSize {
+                width: 4.5,
+                height: 6.0,
+            }
+        );
+    }
+
+    #[test]
+    fn platform_pointer_ids_do_not_collide_with_primary() {
+        let pointer = pointer_info_from_platform_pointer_id(PointerType::Touch, 0);
+        assert_eq!(
+            pointer
+                .pointer_id
+                .expect("platform ids should be assigned")
+                .get_inner()
+                .get(),
+            2
+        );
+        assert!(!pointer.is_primary_pointer());
+    }
+
+    #[test]
+    fn uikit_modifier_bits_map_to_ui_events_modifiers() {
+        let mods = modifiers_from_uikit_modifier_bits(
+            UIKIT_CONTROL_BIT | UIKIT_ALT_BIT | UIKIT_SHIFT_BIT | UIKIT_META_BIT,
+        );
+        assert!(mods.ctrl());
+        assert!(mods.alt());
+        assert!(mods.shift());
+        assert!(mods.meta());
+    }
+
+    #[test]
+    fn hid_usage_maps_modifier_locations() {
+        assert_eq!(
+            hid_usage_to_code_named_location(hid::SHIFT_LEFT),
+            (Code::ShiftLeft, Some(NamedKey::Shift), Location::Left)
+        );
+        assert_eq!(
+            hid_usage_to_code_named_location(hid::META_RIGHT),
+            (Code::MetaRight, Some(NamedKey::Meta), Location::Right)
+        );
+    }
+
+    #[test]
+    fn hid_usage_maps_numpad_keys() {
+        assert_eq!(
+            hid_usage_to_code_named_location(hid::NUMPAD_1),
+            (Code::Numpad1, None, Location::Numpad)
+        );
+        assert_eq!(
+            hid_usage_to_code_named_location(hid::NUMPAD_ENTER),
+            (Code::NumpadEnter, Some(NamedKey::Enter), Location::Numpad)
+        );
+        assert_eq!(
+            hid_usage_to_code_named_location(hid::NUMPAD_EQUAL),
+            (Code::NumpadEqual, None, Location::Numpad)
+        );
+    }
+
+    #[test]
+    fn hid_usage_maps_function_named_keys() {
+        assert_eq!(
+            hid_usage_to_code_named_location(hid::F1),
+            (Code::F1, Some(NamedKey::F1), Location::Standard)
+        );
+        assert_eq!(
+            hid_usage_to_code_named_location(hid::F13),
+            (Code::F13, Some(NamedKey::F13), Location::Standard)
+        );
+        assert_eq!(
+            hid_usage_to_code_named_location(hid::F24),
+            (Code::F24, Some(NamedKey::F24), Location::Standard)
+        );
+    }
+
+    #[test]
+    fn pinch_delta_from_cumulative_scale_uses_scale_ratio() {
+        assert_eq!(pinch_delta_from_cumulative_scale(1.0, 1.25), Some(0.25));
+        assert_eq!(pinch_delta_from_cumulative_scale(2.0, 3.0), Some(0.5));
+        assert_eq!(pinch_delta_from_cumulative_scale(2.0, 1.0), Some(-0.5));
+    }
+
+    #[test]
+    fn pinch_delta_from_cumulative_scale_rejects_invalid_values() {
+        assert_eq!(pinch_delta_from_cumulative_scale(0.0, 1.0), None);
+        assert_eq!(pinch_delta_from_cumulative_scale(1.0, 0.0), None);
+        assert_eq!(pinch_delta_from_cumulative_scale(f64::NAN, 1.0), None);
+        assert_eq!(pinch_delta_from_cumulative_scale(1.0, f64::INFINITY), None);
+    }
+
+    #[test]
+    fn rotation_delta_from_cumulative_rotation_flips_to_clockwise_delta() {
+        assert_eq!(
+            rotation_delta_from_cumulative_rotation(0.25, 0.75),
+            Some(-0.5)
+        );
+        assert_eq!(
+            rotation_delta_from_cumulative_rotation(0.75, 0.25),
+            Some(0.5)
+        );
+    }
+
+    #[test]
+    fn rotation_delta_from_cumulative_rotation_rejects_invalid_values() {
+        assert_eq!(rotation_delta_from_cumulative_rotation(f64::NAN, 0.0), None);
+        assert_eq!(
+            rotation_delta_from_cumulative_rotation(0.0, f64::INFINITY),
+            None
+        );
+    }
+
+    #[test]
+    fn uikit_pen_contact_maps_to_primary_button() {
+        assert_eq!(
+            contact_button_for_uikit_pointer(PointerType::Pen),
+            Some(PointerButton::Primary)
+        );
+
+        let buttons = buttons_from_bitmask(contact_buttons_mask_for_uikit_pointer(
+            PointerType::Pen,
+            true,
+            PointerButton::Secondary as u64,
+        ));
+        assert!(buttons.contains(PointerButton::Primary));
+        assert!(buttons.contains(PointerButton::Secondary));
+    }
+
+    #[test]
+    fn uikit_touch_contact_stays_buttonless() {
+        assert_eq!(contact_button_for_uikit_pointer(PointerType::Touch), None);
+        assert_eq!(
+            contact_buttons_mask_for_uikit_pointer(PointerType::Touch, true, 0),
+            0
+        );
+    }
+}

--- a/ui-events-uikit/src/uikit.rs
+++ b/ui-events-uikit/src/uikit.rs
@@ -1,0 +1,439 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! UIKit (iOS/tvOS) shims that extract fields from `objc2_ui_kit` and forward
+//! to platform-neutral mappers.
+
+// cfg is handled at the module declaration in lib.rs
+
+use alloc::string::ToString;
+use objc2_foundation::NSArray;
+use objc2_ui_kit::{UIEvent, UITouch, UITouchPhase, UITouchType};
+#[cfg(feature = "gestures")]
+use objc2_ui_kit::{
+    UIGestureRecognizerState, UIPinchGestureRecognizer, UIRotationGestureRecognizer,
+};
+use objc2_ui_kit::{UIKey, UIPress, UIPressPhase, UIPressType};
+
+use crate::mapping as map;
+use ui_events::keyboard::Modifiers;
+use ui_events::keyboard::{Code, Key, KeyState, KeyboardEvent, Location, NamedKey};
+use ui_events::pointer::{PointerEvent, PointerState, PointerType};
+#[cfg(feature = "gestures")]
+use ui_events::pointer::{PointerGesture, PointerGestureEvent};
+use ui_events::pointer::{PointerInfo, PointerUpdate};
+
+fn pointer_type_from_touch(touch: &UITouch) -> PointerType {
+    match touch.r#type() {
+        UITouchType::Pencil => PointerType::Pen,
+        _ => PointerType::Touch,
+    }
+}
+
+fn pointer_state_from_touch(
+    touch: &UITouch,
+    scale_factor: f64,
+    pointer_type: PointerType,
+    event_buttons_mask: u64,
+) -> PointerState {
+    let loc = touch.preciseLocationInView(None);
+    let ts = touch.timestamp();
+    let phase = touch.phase();
+
+    let active = matches!(
+        phase,
+        UITouchPhase::Began | UITouchPhase::Moved | UITouchPhase::Stationary
+    );
+    let buttons_mask =
+        map::contact_buttons_mask_for_uikit_pointer(pointer_type, active, event_buttons_mask);
+
+    let force_along_axis = touch.force();
+    let max_force = touch.maximumPossibleForce();
+    let tap_count = i64::try_from(touch.tapCount()).unwrap_or(i64::MAX);
+    let contact_diameter = Some(touch.majorRadius() * 2.0);
+
+    let (altitude, azimuth) = if matches!(pointer_type, PointerType::Pen) {
+        let altitude = touch.altitudeAngle();
+        let azimuth = touch.azimuthAngleInView(None);
+        (Some(altitude), Some(azimuth))
+    } else {
+        (None, None)
+    };
+
+    let pressure = map::pressure_from_force(
+        active,
+        Some(force_along_axis),
+        Some(max_force),
+        altitude,
+        matches!(pointer_type, PointerType::Pen),
+    );
+
+    let state = map::pointer_state_from_raw(
+        loc.x,
+        loc.y,
+        scale_factor,
+        buttons_mask,
+        false,
+        false,
+        false,
+        false,
+        Some(pressure),
+        // UIKit exposes stylus rollAngle, not tangential pressure.
+        None,
+        contact_diameter,
+        contact_diameter,
+        ts,
+        tap_count,
+    );
+
+    #[allow(
+        clippy::cast_possible_truncation,
+        reason = "UIKit provides f64 radians; ui-events stores orientation as f32"
+    )]
+    if let (Some(alt), Some(azi)) = (altitude, azimuth) {
+        ui_events::pointer::PointerState {
+            orientation: ui_events::pointer::PointerOrientation {
+                altitude: alt as f32,
+                azimuth: azi as f32,
+            },
+            ..state
+        }
+    } else {
+        state
+    }
+}
+
+fn event_buttons_mask(event: Option<&UIEvent>) -> u64 {
+    event
+        .and_then(|event| u64::try_from(event.buttonMask().bits()).ok())
+        .unwrap_or_default()
+}
+
+fn pointer_info_from_touch(touch: &UITouch) -> PointerInfo {
+    let pointer_token = u64::try_from(touch as *const UITouch as usize)
+        .expect("object pointers always fit into u64");
+    map::pointer_info_from_platform_pointer_id(pointer_type_from_touch(touch), pointer_token)
+}
+
+/// Convert a `UITouch` + `UIEvent` into a `PointerEvent`.
+///
+/// This is the preferred entry point when handling `touchesBegan/Moved/Ended/Cancelled`,
+/// since `UIEvent` is where UIKit exposes coalesced and predicted touch samples.
+///
+/// Positions come from `UITouch::preciseLocationInView(None)`, so they use
+/// UIKit's coordinate conventions for the touch's window. This helper only
+/// scales point values into physical pixels; hosts that need another view's
+/// coordinate space should convert before or after calling it.
+///
+/// Touch timestamps are UIKit's monotonic seconds-since-boot timebase, not Unix
+/// epoch time.
+///
+/// Pencil hover is also handled here when UIKit reports `RegionEntered`, `RegionMoved`,
+/// and `RegionExited` touch phases.
+pub fn pointer_event_from_touch_and_event(
+    touch: &UITouch,
+    event: &UIEvent,
+    scale_factor: f64,
+) -> Option<PointerEvent> {
+    let phase = touch.phase();
+    let pointer_type = pointer_type_from_touch(touch);
+    let pointer = pointer_info_from_touch(touch);
+    let event_buttons_mask = event_buttons_mask(Some(event));
+
+    // `coalescedTouchesForTouch:` is most useful for move-like phases where we can fill
+    // `PointerUpdate.coalesced`; for other phases we just return the single-sample event.
+    if !matches!(phase, UITouchPhase::Moved | UITouchPhase::Stationary) {
+        return pointer_event_from_touch_impl(touch, scale_factor, event_buttons_mask);
+    }
+
+    let mut predicted = alloc::vec![];
+    if let Some(arr) = event.predictedTouchesForTouch(touch) {
+        predicted =
+            pointer_states_from_nsarray(&arr, scale_factor, pointer_type, event_buttons_mask);
+    }
+
+    let Some(arr) = event.coalescedTouchesForTouch(touch) else {
+        return Some(PointerEvent::Move(PointerUpdate {
+            pointer,
+            current: pointer_state_from_touch(
+                touch,
+                scale_factor,
+                pointer_type,
+                event_buttons_mask,
+            ),
+            coalesced: alloc::vec![],
+            predicted,
+        }));
+    };
+
+    let mut samples =
+        pointer_states_from_nsarray(&arr, scale_factor, pointer_type, event_buttons_mask);
+    let current = samples.pop().unwrap_or_else(|| {
+        pointer_state_from_touch(touch, scale_factor, pointer_type, event_buttons_mask)
+    });
+
+    Some(PointerEvent::Move(PointerUpdate {
+        pointer,
+        current,
+        coalesced: samples,
+        predicted,
+    }))
+}
+
+fn pointer_states_from_nsarray(
+    arr: &NSArray<UITouch>,
+    scale_factor: f64,
+    pointer_type: PointerType,
+    event_buttons_mask: u64,
+) -> alloc::vec::Vec<PointerState> {
+    let mut out = alloc::vec![];
+    let n = arr.count();
+    out.reserve(n);
+    for i in 0..n {
+        let sample = arr.objectAtIndex(i);
+        out.push(pointer_state_from_touch(
+            &sample,
+            scale_factor,
+            pointer_type,
+            event_buttons_mask,
+        ));
+    }
+    out
+}
+
+/// Convert a `UITouch` into a `PointerEvent`.
+///
+/// This is an uncommon convenience entry point for situations where you do not have
+/// access to the associated `UIEvent`. Without `UIEvent`, UIKit does not expose
+/// coalesced or predicted touch samples, so `PointerUpdate.coalesced/predicted` will be empty.
+///
+/// Coordinates and timestamps follow the same conventions as
+/// [`pointer_event_from_touch_and_event`].
+///
+/// Pencil hover is also handled here when UIKit reports `RegionEntered`, `RegionMoved`,
+/// and `RegionExited` touch phases.
+pub fn pointer_event_from_touch(touch: &UITouch, scale_factor: f64) -> Option<PointerEvent> {
+    pointer_event_from_touch_impl(touch, scale_factor, 0)
+}
+
+fn pointer_event_from_touch_impl(
+    touch: &UITouch,
+    scale_factor: f64,
+    event_buttons_mask: u64,
+) -> Option<PointerEvent> {
+    let phase = touch.phase();
+    let pointer_type = pointer_type_from_touch(touch);
+    let pointer = pointer_info_from_touch(touch);
+    let state = pointer_state_from_touch(touch, scale_factor, pointer_type, event_buttons_mask);
+    let button = map::contact_button_for_uikit_pointer(pointer_type);
+
+    Some(match phase {
+        UITouchPhase::Began => PointerEvent::Down(ui_events::pointer::PointerButtonEvent {
+            button,
+            pointer,
+            state,
+        }),
+        UITouchPhase::Moved | UITouchPhase::Stationary => PointerEvent::Move(PointerUpdate {
+            pointer,
+            current: state,
+            coalesced: alloc::vec![],
+            predicted: alloc::vec![],
+        }),
+        UITouchPhase::Ended => PointerEvent::Up(ui_events::pointer::PointerButtonEvent {
+            button,
+            pointer,
+            state,
+        }),
+        UITouchPhase::RegionEntered if matches!(pointer_type, PointerType::Pen) => {
+            PointerEvent::Enter(pointer)
+        }
+        UITouchPhase::RegionMoved if matches!(pointer_type, PointerType::Pen) => {
+            PointerEvent::Move(PointerUpdate {
+                pointer,
+                current: state,
+                coalesced: alloc::vec![],
+                predicted: alloc::vec![],
+            })
+        }
+        UITouchPhase::RegionExited if matches!(pointer_type, PointerType::Pen) => {
+            PointerEvent::Leave(pointer)
+        }
+        UITouchPhase::Cancelled => PointerEvent::Cancel(pointer),
+        _ => return None,
+    })
+}
+
+/// Convert a `UIPinchGestureRecognizer` into a `PointerEvent::Gesture`.
+///
+/// This is a lightweight convenience helper intended to be called from a
+/// `UIPinchGestureRecognizer` callback.
+///
+/// Notes:
+/// - Returns `None` unless the recognizer is in `Began` or `Changed` state.
+/// - `previous_scale` must be the previous cumulative `gesture.scale()` value,
+///   or `1.0` for the first update in a gesture.
+/// - UIKit reports `scale` as a cumulative multiplicative factor; this helper
+///   differences it against `previous_scale` so the returned
+///   [`PointerGesture::Pinch`] satisfies the `ui-events` per-update delta
+///   contract.
+/// - The returned [`PointerState::time`] is 0, since gesture recognizers do not expose a timestamp.
+#[cfg(feature = "gestures")]
+pub fn pointer_gesture_from_uipinch(
+    gesture: &UIPinchGestureRecognizer,
+    scale_factor: f64,
+    previous_scale: f64,
+) -> Option<PointerEvent> {
+    let gr_state: UIGestureRecognizerState = gesture.state();
+    if !(gr_state == UIGestureRecognizerState::Began
+        || gr_state == UIGestureRecognizerState::Changed)
+    {
+        return None;
+    }
+    let loc = gesture.locationInView(None);
+    let scale = gesture.scale();
+    let pinch = map::pinch_delta_from_cumulative_scale(previous_scale, scale)?;
+    let state = map::pointer_state_from_raw(
+        loc.x,
+        loc.y,
+        scale_factor,
+        0,
+        false,
+        false,
+        false,
+        false,
+        None,
+        None,
+        None,
+        None,
+        0.0,
+        0,
+    );
+    Some(PointerEvent::Gesture(PointerGestureEvent {
+        pointer: map::pointer_info_primary_for_type(PointerType::Touch),
+        gesture: PointerGesture::Pinch(pinch),
+        state,
+    }))
+}
+
+/// Convert a `UIRotationGestureRecognizer` into a `PointerEvent::Gesture`.
+///
+/// This is a lightweight convenience helper intended to be called from a
+/// `UIRotationGestureRecognizer` callback.
+///
+/// Notes:
+/// - Returns `None` unless the recognizer is in `Began` or `Changed` state.
+/// - `previous_rotation_ccw` must be the previous cumulative
+///   `gesture.rotation()` value, or `0.0` for the first update in a gesture.
+/// - UIKit reports rotation as cumulative counterclockwise radians; this helper
+///   differences it against `previous_rotation_ccw` and flips the sign so the
+///   returned [`PointerGesture::Rotate`] satisfies the `ui-events`
+///   clockwise-per-update delta contract.
+/// - The returned [`PointerState::time`] is 0, since gesture recognizers do not expose a timestamp.
+#[cfg(feature = "gestures")]
+pub fn pointer_gesture_from_uirotation(
+    gesture: &UIRotationGestureRecognizer,
+    scale_factor: f64,
+    previous_rotation_ccw: f64,
+) -> Option<PointerEvent> {
+    let gr_state: UIGestureRecognizerState = gesture.state();
+    if !(gr_state == UIGestureRecognizerState::Began
+        || gr_state == UIGestureRecognizerState::Changed)
+    {
+        return None;
+    }
+    let loc = gesture.locationInView(None);
+    let rotation_ccw = gesture.rotation();
+    let rotation_cw =
+        map::rotation_delta_from_cumulative_rotation(previous_rotation_ccw, rotation_ccw)?;
+    let state = map::pointer_state_from_raw(
+        loc.x,
+        loc.y,
+        scale_factor,
+        0,
+        false,
+        false,
+        false,
+        false,
+        None,
+        None,
+        None,
+        None,
+        0.0,
+        0,
+    );
+    Some(PointerEvent::Gesture(PointerGestureEvent {
+        pointer: map::pointer_info_primary_for_type(PointerType::Touch),
+        gesture: PointerGesture::Rotate(rotation_cw),
+        state,
+    }))
+}
+
+/// Convert a `UIPress` (tvOS/Apple TV remote) into a `KeyboardEvent`.
+pub fn keyboard_event_from_uipress(press: &UIPress) -> Option<KeyboardEvent> {
+    let state = match press.phase() {
+        UIPressPhase::Began => KeyState::Down,
+        UIPressPhase::Ended | UIPressPhase::Cancelled => KeyState::Up,
+        _ => return None,
+    };
+    let key = match press.r#type() {
+        UIPressType::UpArrow => Key::Named(NamedKey::ArrowUp),
+        UIPressType::DownArrow => Key::Named(NamedKey::ArrowDown),
+        UIPressType::LeftArrow => Key::Named(NamedKey::ArrowLeft),
+        UIPressType::RightArrow => Key::Named(NamedKey::ArrowRight),
+        UIPressType::Select => Key::Named(NamedKey::Select),
+        UIPressType::Menu => Key::Named(NamedKey::Escape),
+        UIPressType::PlayPause => Key::Named(NamedKey::MediaPlayPause),
+        _ => Key::Named(NamedKey::Unidentified),
+    };
+    Some(KeyboardEvent {
+        state,
+        key,
+        code: Code::Unidentified,
+        location: Location::Standard,
+        modifiers: Modifiers::default(),
+        is_composing: false,
+        repeat: false,
+    })
+}
+
+/// Convert a `UIPress` that carries a `UIKey` (hardware keyboard) into a `KeyboardEvent`.
+pub fn keyboard_event_from_uikey(press: &UIPress, key: &UIKey) -> Option<KeyboardEvent> {
+    let state = match press.phase() {
+        UIPressPhase::Began => KeyState::Down,
+        UIPressPhase::Ended | UIPressPhase::Cancelled => KeyState::Up,
+        _ => return None,
+    };
+
+    let usage = u16::try_from(key.keyCode().0).ok();
+    let (code, named, location) = usage.map(map::hid_usage_to_code_named_location).unwrap_or((
+        Code::Unidentified,
+        Some(NamedKey::Unidentified),
+        Location::Standard,
+    ));
+    let modifier_bits = u64::try_from(key.modifierFlags().bits()).unwrap_or_default();
+    let modifiers = map::modifiers_from_uikit_modifier_bits(modifier_bits);
+
+    let characters = key.characters().to_string();
+    let key_value = if let Some(named) = named {
+        Key::Named(named)
+    } else if characters.chars().count() == 1 {
+        Key::Character(characters)
+    } else {
+        let unmodified = key.charactersIgnoringModifiers().to_string();
+        if unmodified.chars().count() == 1 {
+            Key::Character(unmodified)
+        } else {
+            Key::Named(NamedKey::Unidentified)
+        }
+    };
+
+    Some(KeyboardEvent {
+        state,
+        key: key_value,
+        code,
+        location,
+        modifiers,
+        is_composing: false,
+        repeat: false,
+    })
+}

--- a/ui-events-web/src/pointer.rs
+++ b/ui-events-web/src/pointer.rs
@@ -921,7 +921,9 @@ mod stylus_orientation_tests {
         let o = pointer_orientation_from_tilt_degrees(25.0, -10.0);
         let o_neg = pointer_orientation_from_tilt_degrees(-25.0, 10.0);
 
-        assert_approx(o.altitude, o_neg.altitude, 1e-6);
+        // `f32` trig can differ by just over 1e-6 radians on Miri's
+        // cross-target interpreter while preserving the symmetry invariant.
+        assert_approx(o.altitude, o_neg.altitude, 2e-6);
         assert_azimuth_approx(o_neg.azimuth, o.azimuth + core::f32::consts::PI, 1e-6);
     }
 


### PR DESCRIPTION
Add text-free `AppKitInputResponder` and `UIKitInputResponder` types that translate platform responder callbacks into `ui-events` pointer and keyboard events. Keep text input, IME, and edit commands out of this slice so the first Apple adapter commit can land without committing to the text API.

Make UIKit touch handling part of the baseline target surface instead of a separate `touch` feature, while keeping gesture recognizers behind `gestures`.

Update `simple_appkit` to install `AppKitInputResponder` in the normal `NSResponder` chain. Update CI and `.clippy.toml` so `AppKit` and `UIKit` are covered by MSRV and explicit Apple adapter `no_std` checks.