### PR TITLE
web: relax stylus azimuth miri tolerance

### DIFF
--- a/ui-events-web/src/pointer.rs
+++ b/ui-events-web/src/pointer.rs
@@ -924,7 +924,7 @@ mod stylus_orientation_tests {
         // `f32` trig can differ by just over 1e-6 radians on Miri's
         // cross-target interpreter while preserving the symmetry invariant.
         assert_approx(o.altitude, o_neg.altitude, 2e-6);
-        assert_azimuth_approx(o_neg.azimuth, o.azimuth + core::f32::consts::PI, 1e-6);
+        assert_azimuth_approx(o_neg.azimuth, o.azimuth + core::f32::consts::PI, 2e-6);
     }
 
     #[test]


### PR DESCRIPTION
Use the same tolerance for the azimuth symmetry assertion that the test already documents for Miri f32 trig variance.

The observed Miri delta is just over 1e-6 radians while preserving the expected pi-flip symmetry.