### PR TITLE
wayland: add ui-events-wayland adapter crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,15 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
+      - name: install libxkbcommon (Linux)
+        # The ui-events-wayland `xkb` feature, enabled by `--all-features`, links
+        # the system libxkbcommon; `xkb-data` lets its keymap tests run instead of
+        # skipping. Only the Linux job builds and runs this dependency.
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxkbcommon-dev xkb-data
+
       - name: cargo nextest
         run: cargo nextest run --workspace --locked --all-features --no-fail-fast
 
@@ -297,7 +306,10 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: cargo check
-        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --features std
+        # The ui-events-wayland `xkb` feature pulls in xkbcommon, a third-party
+        # binding to the system libxkbcommon that declares no MSRV, so it is
+        # excluded here and not covered by this workspace's MSRV guarantee.
+        run: cargo hack check ${{ env.RUST_MIN_VER_PKGS }} --locked --optional-deps --each-feature --ignore-unknown-features --exclude-features xkb --features std
 
   check-msrv-no-std:
     name: cargo check (msrv)
@@ -376,7 +388,15 @@ jobs:
           save-if: ${{ github.event_name != 'merge_group' }}
 
       - name: cargo miri
-        run: cargo miri test --workspace --locked --all-features --target s390x-unknown-linux-gnu --no-fail-fast
+        # The ui-events-wayland `xkb` feature links the system libxkbcommon (C),
+        # which is unavailable to this cross-compiled job and outside Miri's
+        # reach. Run the rest of the workspace with all features, then the
+        # wayland adapter separately with its default (xkb-free) features so its
+        # mapping and reducer tests still run under Miri.
+        run: cargo miri test --workspace --exclude ui-events-wayland --locked --all-features --target s390x-unknown-linux-gnu --no-fail-fast
+
+      - name: cargo miri (ui-events-wayland)
+        run: cargo miri test -p ui-events-wayland --locked --target s390x-unknown-linux-gnu --no-fail-fast
 
   doc:
     name: cargo doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   RUST_MIN_NO_STD_VER: "1.85"
   # List of packages that will be checked with the minimum supported Rust version.
   # This should be limited to packages that are intended for publishing.
-  RUST_MIN_VER_PKGS: "-p ui-events -p ui-events-apple-common -p ui-events-appkit -p ui-events-uikit -p ui-events-web -p ui-events-winit -p ui-input-state -p ui-theme"
+  RUST_MIN_VER_PKGS: "-p ui-events -p ui-events-apple-common -p ui-events-appkit -p ui-events-uikit -p ui-events-wayland -p ui-events-web -p ui-events-winit -p ui-input-state -p ui-theme"
   # List of packages that will be checked for `no_std` builds.
   # This should be limited to packages that are intended for publishing.
   RUST_NO_STD_PKGS: "-p ui-events -p ui-events-apple-common -p ui-events-appkit -p ui-events-uikit -p ui-input-state -p ui-theme"
@@ -116,6 +116,9 @@ jobs:
 
       - name: cargo rdme (ui-events-uikit)
         run: cargo rdme --workspace-project=ui-events-uikit --heading-base-level=0 --check
+
+      - name: cargo rdme (ui-events-wayland)
+        run: cargo rdme --workspace-project=ui-events-wayland --heading-base-level=0 --check
 
       - name: cargo rdme (ui-events-web)
         run: cargo rdme --workspace-project=ui-events-web --heading-base-level=0 --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,10 @@ env:
   RUST_MIN_VER_PKGS: "-p ui-events -p ui-events-apple-common -p ui-events-appkit -p ui-events-uikit -p ui-events-wayland -p ui-events-web -p ui-events-winit -p ui-input-state -p ui-theme"
   # List of packages that will be checked for `no_std` builds.
   # This should be limited to packages that are intended for publishing.
-  RUST_NO_STD_PKGS: "-p ui-events -p ui-events-apple-common -p ui-events-appkit -p ui-events-uikit -p ui-input-state -p ui-theme"
+  RUST_NO_STD_PKGS: "-p ui-events -p ui-events-apple-common -p ui-events-appkit -p ui-events-uikit -p ui-events-wayland -p ui-input-state -p ui-theme"
   # List of features that depend on the standard library and will be excluded from no_std checks.
-  FEATURES_DEPENDING_ON_STD: "std,default"
+  # ui-events-wayland's `xkb` reads the keymap fd through `std::fs`, so it implies `std`.
+  FEATURES_DEPENDING_ON_STD: "std,default,xkb"
 
 
 # Rationale

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ version = "0.3.0"
 dependencies = [
  "dpi",
  "ui-events",
+ "wayland-client",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,6 +1367,7 @@ dependencies = [
  "ui-events",
  "wayland-client",
  "wayland-protocols",
+ "xkbcommon",
 ]
 
 [[package]]
@@ -1900,6 +1901,16 @@ name = "xcursor"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
+
+[[package]]
+name = "xkbcommon"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7a974f48060a14e95705c01f24ad9c3345022f4d97441b8a36beb7ed5c4a02d"
+dependencies = [
+ "libc",
+ "xkeysym",
+]
 
 [[package]]
 name = "xkbcommon-dl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,6 +1364,7 @@ name = "ui-events-wayland"
 version = "0.3.0"
 dependencies = [
  "dpi",
+ "libm",
  "ui-events",
  "wayland-client",
  "wayland-protocols",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,7 @@ dependencies = [
  "dpi",
  "ui-events",
  "wayland-client",
+ "wayland-protocols",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,6 +1360,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ui-events-wayland"
+version = "0.3.0"
+dependencies = [
+ "dpi",
+ "ui-events",
+]
+
+[[package]]
 name = "ui-events-web"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "ui-events-apple-common",
     "ui-events-appkit",
     "ui-events-uikit",
+    "ui-events-wayland",
     "ui-events-web",
     "ui-events-winit",
     "ui-input-state",

--- a/ui-events-wayland/CHANGELOG.md
+++ b/ui-events-wayland/CHANGELOG.md
@@ -1,0 +1,26 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+UI Events Wayland has not yet been published.
+
+## [Unreleased]
+
+This release has an [MSRV][] of 1.85.
+
+### Added
+
+- Platform-neutral Wayland input mapping helpers in the `mapping` module:
+  evdev pointer-button mapping, surface-local coordinate scaling, scroll-axis
+  frame to `ScrollDelta` conversion, pointer identity helpers, and modifier
+  helpers.
+
+[Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
+
+[MSRV]: README.md#minimum-supported-rust-version-msrv

--- a/ui-events-wayland/CHANGELOG.md
+++ b/ui-events-wayland/CHANGELOG.md
@@ -20,6 +20,9 @@ This release has an [MSRV][] of 1.85.
   evdev pointer-button mapping, surface-local coordinate scaling, scroll-axis
   frame to `ScrollDelta` conversion, pointer identity helpers, and modifier
   helpers.
+- `pointer::PointerEventReducer`, which reduces a `wl_pointer` event stream into
+  `PointerEvent`s, accumulating frame-batched scroll axes, tracking button and
+  click-count state, and stamping a caller-provided monotonic timestamp.
 
 [Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
 

--- a/ui-events-wayland/CHANGELOG.md
+++ b/ui-events-wayland/CHANGELOG.md
@@ -18,11 +18,15 @@ This release has an [MSRV][] of 1.85.
 
 - Platform-neutral Wayland input mapping helpers in the `mapping` module:
   evdev pointer-button mapping, surface-local coordinate scaling, scroll-axis
-  frame to `ScrollDelta` conversion, pointer identity helpers, and modifier
-  helpers.
+  frame to `ScrollDelta` conversion, pointer and touch identity helpers, touch
+  contact-geometry and orientation conversions, and modifier helpers.
 - `pointer::PointerEventReducer`, which reduces a `wl_pointer` event stream into
   `PointerEvent`s, accumulating frame-batched scroll axes, tracking button and
   click-count state, and stamping a caller-provided monotonic timestamp.
+- `touch::TouchEventReducer`, which reduces a `wl_touch` event stream into touch
+  `PointerEvent`s, tracking each contact's state, frame-batching shape and
+  orientation updates, mapping the lowest active contact to the primary pointer,
+  and stamping a caller-provided monotonic timestamp.
 
 [Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
 

--- a/ui-events-wayland/CHANGELOG.md
+++ b/ui-events-wayland/CHANGELOG.md
@@ -19,7 +19,8 @@ This release has an [MSRV][] of 1.85.
 - Platform-neutral Wayland input mapping helpers in the `mapping` module:
   evdev pointer-button mapping, surface-local coordinate scaling, scroll-axis
   frame to `ScrollDelta` conversion, pointer and touch identity helpers, touch
-  contact-geometry and orientation conversions, and modifier helpers.
+  contact-geometry and orientation conversions, modifier helpers, and pinch
+  scale-fraction and rotation conversions.
 - `pointer::PointerEventReducer`, which reduces a `wl_pointer` event stream into
   `PointerEvent`s, accumulating frame-batched scroll axes, tracking button and
   click-count state, and stamping a caller-provided monotonic timestamp.
@@ -27,6 +28,10 @@ This release has an [MSRV][] of 1.85.
   `PointerEvent`s, tracking each contact's state, frame-batching shape and
   orientation updates, mapping the lowest active contact to the primary pointer,
   and stamping a caller-provided monotonic timestamp.
+- `gesture::PinchGestureReducer`, which reduces a `zwp_pointer_gesture_pinch_v1`
+  touchpad pinch event stream into pinch and rotate `PointerEvent`s, converting
+  Wayland's absolute scale into a per-update scale fraction and its
+  clockwise-degree rotation into radians.
 
 [Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
 

--- a/ui-events-wayland/CHANGELOG.md
+++ b/ui-events-wayland/CHANGELOG.md
@@ -20,10 +20,12 @@ This release has an [MSRV][] of 1.85.
   evdev pointer-button mapping, surface-local coordinate scaling, scroll-axis
   frame to `ScrollDelta` conversion, pointer and touch identity helpers, touch
   contact-geometry and orientation conversions, modifier helpers, an evdev
-  keyboard scancode to physical-key `Code` mapping, pinch scale-fraction and
-  rotation conversions, and tablet-tool helpers (stylus-button
-  mapping, tool-type to pointer-type and tip-button mapping, normalized pressure
-  and slider conversions, and tilt-to-orientation conversion).
+  keyboard scancode to physical-key `Code` mapping, XKB keysym to named-key and
+  logical-key mapping, physical-`Code` to key-location mapping, a keymap-active
+  modifiers to modifier-set helper, pinch scale-fraction and rotation
+  conversions, and tablet-tool helpers (stylus-button mapping, tool-type to
+  pointer-type and tip-button mapping, normalized pressure and slider
+  conversions, and tilt-to-orientation conversion).
 - `pointer::PointerEventReducer`, which reduces a `wl_pointer` event stream into
   `PointerEvent`s, accumulating frame-batched scroll axes, tracking button and
   click-count state, and stamping a caller-provided monotonic timestamp.
@@ -45,6 +47,10 @@ This release has an [MSRV][] of 1.85.
   and key state, self-tracking the modifier set from the physical modifier keys,
   seeding pressed-key state on focus enter, and exposing the key-repeat
   parameters. Logical key values and typed text require the `xkb` feature.
+- An optional, non-default `xkb` feature for `keyboard::KeyboardEventReducer`
+  that links `libxkbcommon` and uses the compositor's keymap to resolve logical
+  key values, typed text, the key location, and the authoritative modifier set
+  (including the lock states and the Alt Graph modifier).
 
 [Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
 

--- a/ui-events-wayland/CHANGELOG.md
+++ b/ui-events-wayland/CHANGELOG.md
@@ -51,6 +51,10 @@ This release has an [MSRV][] of 1.85.
   that links `libxkbcommon` and uses the compositor's keymap to resolve logical
   key values, typed text, the key location, and the authoritative modifier set
   (including the lock states and the Alt Graph modifier).
+- `seat::SeatReducer`, which aggregates a seat's pointer, keyboard, and touch
+  reducers behind its `wl_seat` capabilities, routing each device's events into
+  a uniform `SeatEventTranslation` stream and dropping a device's reducer when
+  its capability is withdrawn.
 
 [Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
 

--- a/ui-events-wayland/CHANGELOG.md
+++ b/ui-events-wayland/CHANGELOG.md
@@ -14,6 +14,9 @@ UI Events Wayland has not yet been published.
 
 This release has an [MSRV][] of 1.85.
 
+The crate is `no_std` (using `alloc`); enabling the `xkb` feature additionally
+requires `std`.
+
 ### Added
 
 - Platform-neutral Wayland input mapping helpers in the `mapping` module:

--- a/ui-events-wayland/CHANGELOG.md
+++ b/ui-events-wayland/CHANGELOG.md
@@ -19,8 +19,10 @@ This release has an [MSRV][] of 1.85.
 - Platform-neutral Wayland input mapping helpers in the `mapping` module:
   evdev pointer-button mapping, surface-local coordinate scaling, scroll-axis
   frame to `ScrollDelta` conversion, pointer and touch identity helpers, touch
-  contact-geometry and orientation conversions, modifier helpers, and pinch
-  scale-fraction and rotation conversions.
+  contact-geometry and orientation conversions, modifier helpers, pinch
+  scale-fraction and rotation conversions, and tablet-tool helpers (stylus-button
+  mapping, tool-type to pointer-type and tip-button mapping, normalized pressure
+  and slider conversions, and tilt-to-orientation conversion).
 - `pointer::PointerEventReducer`, which reduces a `wl_pointer` event stream into
   `PointerEvent`s, accumulating frame-batched scroll axes, tracking button and
   click-count state, and stamping a caller-provided monotonic timestamp.
@@ -32,6 +34,11 @@ This release has an [MSRV][] of 1.85.
   touchpad pinch event stream into pinch and rotate `PointerEvent`s, converting
   Wayland's absolute scale into a per-update scale fraction and its
   clockwise-degree rotation into radians.
+- `tablet::TabletToolReducer`, which reduces a `zwp_tablet_tool_v2` event stream
+  into pen `PointerEvent`s, frame-batching the tool's position and pressure,
+  tilt, and slider axes, mapping the tip and stylus barrel buttons (an eraser
+  tool's tip to the pen-eraser button), surfacing proximity as enter and leave,
+  and stamping a caller-provided monotonic timestamp.
 
 [Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
 

--- a/ui-events-wayland/CHANGELOG.md
+++ b/ui-events-wayland/CHANGELOG.md
@@ -19,8 +19,9 @@ This release has an [MSRV][] of 1.85.
 - Platform-neutral Wayland input mapping helpers in the `mapping` module:
   evdev pointer-button mapping, surface-local coordinate scaling, scroll-axis
   frame to `ScrollDelta` conversion, pointer and touch identity helpers, touch
-  contact-geometry and orientation conversions, modifier helpers, pinch
-  scale-fraction and rotation conversions, and tablet-tool helpers (stylus-button
+  contact-geometry and orientation conversions, modifier helpers, an evdev
+  keyboard scancode to physical-key `Code` mapping, pinch scale-fraction and
+  rotation conversions, and tablet-tool helpers (stylus-button
   mapping, tool-type to pointer-type and tip-button mapping, normalized pressure
   and slider conversions, and tilt-to-orientation conversion).
 - `pointer::PointerEventReducer`, which reduces a `wl_pointer` event stream into
@@ -39,6 +40,11 @@ This release has an [MSRV][] of 1.85.
   tilt, and slider axes, mapping the tip and stylus barrel buttons (an eraser
   tool's tip to the pen-eraser button), surfacing proximity as enter and leave,
   and stamping a caller-provided monotonic timestamp.
+- `keyboard::KeyboardEventReducer`, which reduces a `wl_keyboard` event stream
+  into `KeyboardEvent`s, mapping each evdev scancode to its physical W3C `Code`
+  and key state, self-tracking the modifier set from the physical modifier keys,
+  seeding pressed-key state on focus enter, and exposing the key-repeat
+  parameters. Logical key values and typed text require the `xkb` feature.
 
 [Unreleased]: https://github.com/endoli/ui-events/compare/v0.3.0...HEAD
 

--- a/ui-events-wayland/Cargo.toml
+++ b/ui-events-wayland/Cargo.toml
@@ -21,6 +21,7 @@ dpi.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 wayland-client = "0.31"
+wayland-protocols = { version = "0.32", features = ["client", "unstable"] }
 
 [lints]
 workspace = true

--- a/ui-events-wayland/Cargo.toml
+++ b/ui-events-wayland/Cargo.toml
@@ -19,5 +19,8 @@ targets = []
 ui-events = { workspace = true, features = ["std"] }
 dpi.workspace = true
 
+[target.'cfg(target_os = "linux")'.dependencies]
+wayland-client = "0.31"
+
 [lints]
 workspace = true

--- a/ui-events-wayland/Cargo.toml
+++ b/ui-events-wayland/Cargo.toml
@@ -16,14 +16,21 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [features]
+default = ["std"]
+# `no_std` builds require `libm`, which supplies the trigonometry the tablet and
+# touch mapping use; see the crate-level documentation.
+std = ["ui-events/std", "dpi/std"]
+libm = ["dep:libm"]
 # Resolve logical keys, typed text, and authoritative modifiers from the
 # compositor's XKB keymap. This pulls in `xkbcommon`, which links the system
 # `libxkbcommon`; without it the keyboard reducer resolves only physical keys.
-xkb = ["dep:xkbcommon"]
+# Reading the keymap file descriptor uses `std::fs`, so `xkb` implies `std`.
+xkb = ["dep:xkbcommon", "std"]
 
 [dependencies]
-ui-events = { workspace = true, features = ["std"] }
+ui-events.workspace = true
 dpi.workspace = true
+libm = { version = "0.2.15", optional = true, default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 wayland-client = "0.31"

--- a/ui-events-wayland/Cargo.toml
+++ b/ui-events-wayland/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ui-events-wayland"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+description = "Bridges Wayland input events into ui-events"
+keywords = ["wayland", "linux", "input", "pointer"]
+categories = ["gui"]
+repository.workspace = true
+rust-version.workspace = true
+publish = false
+
+[package.metadata.docs.rs]
+all-features = true
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+
+[dependencies]
+ui-events = { workspace = true, features = ["std"] }
+dpi.workspace = true
+
+[lints]
+workspace = true

--- a/ui-events-wayland/Cargo.toml
+++ b/ui-events-wayland/Cargo.toml
@@ -15,6 +15,12 @@ all-features = true
 default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
+[features]
+# Resolve logical keys, typed text, and authoritative modifiers from the
+# compositor's XKB keymap. This pulls in `xkbcommon`, which links the system
+# `libxkbcommon`; without it the keyboard reducer resolves only physical keys.
+xkb = ["dep:xkbcommon"]
+
 [dependencies]
 ui-events = { workspace = true, features = ["std"] }
 dpi.workspace = true
@@ -22,6 +28,7 @@ dpi.workspace = true
 [target.'cfg(target_os = "linux")'.dependencies]
 wayland-client = "0.31"
 wayland-protocols = { version = "0.32", features = ["client", "unstable"] }
+xkbcommon = { version = "0.9", optional = true, default-features = false }
 
 [lints]
 workspace = true

--- a/ui-events-wayland/LICENSE-APACHE
+++ b/ui-events-wayland/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/ui-events-wayland/LICENSE-MIT
+++ b/ui-events-wayland/LICENSE-MIT
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ui-events-wayland/README.md
+++ b/ui-events-wayland/README.md
@@ -63,6 +63,13 @@ links `libxkbcommon` and uses the compositor's keymap to resolve logical key
 values, typed text, and the authoritative modifier set (including the lock
 states and Alt Graph).
 
+## Feature policy
+
+- `std` is enabled by default.
+- `no_std` builds require `libm`, which supplies the trigonometry the tablet
+  and touch mapping use.
+- `xkb` reads the compositor keymap through `std::fs`, so it implies `std`.
+
 [`PointerState`]: ui_events::pointer::PointerState
 [`ui-events`]: https://docs.rs/ui-events/
 

--- a/ui-events-wayland/README.md
+++ b/ui-events-wayland/README.md
@@ -1,0 +1,107 @@
+<div align="center">
+
+# UI Events Wayland Adapter
+
+A library for bridging Wayland input events into the [`ui-events`] model.
+
+[![Linebender Zulip, #general channel](https://img.shields.io/badge/Linebender-%23general-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/147921-general)
+[![dependency status](https://deps.rs/repo/github/endoli/ui-events/status.svg)](https://deps.rs/repo/github/endoli/ui-events)
+[![Apache 2.0 or MIT license.](https://img.shields.io/badge/license-Apache--2.0_OR_MIT-blue.svg)](#license)
+[![Build status](https://github.com/endoli/ui-events/workflows/CI/badge.svg)](https://github.com/endoli/ui-events/actions)
+[![Crates.io](https://img.shields.io/crates/v/ui-events-wayland.svg)](https://crates.io/crates/ui-events-wayland)
+[![Docs](https://docs.rs/ui-events-wayland/badge.svg)](https://docs.rs/ui-events-wayland)
+
+</div>
+
+<!-- We use cargo-rdme to update the README with the contents of lib.rs.
+To edit the following section, update it in lib.rs, then run:
+cargo rdme --workspace-project=ui-events-wayland --heading-base-level=0
+Full documentation at https://github.com/orium/cargo-rdme -->
+
+<!-- Intra-doc links used in lib.rs should be evaluated here.
+See https://linebender.org/blog/doc-include/ for related discussion. -->
+[`ui-events`]: https://docs.rs/ui-events/
+[`PointerState`]: https://docs.rs/ui-events/latest/ui_events/pointer/struct.PointerState.html
+<!-- cargo-rdme start -->
+
+Bridges Wayland input into the [`ui-events`] model.
+
+This crate is Linux-only in practice. The `wayland-client` protocol bindings
+it builds on are depended upon only on `cfg(target_os = "linux")` targets,
+and the stateful reducers that consume them are gated the same way. On every
+other target the crate compiles to an essentially empty library, so it can
+live in a cross-platform workspace without pulling in platform dependencies.
+
+## Architecture
+
+- [`mapping`] holds platform-neutral, value-based conversions from Wayland
+  input primitives (evdev button codes, surface-local coordinates, axis
+  values, modifier booleans) into [`ui-events`] building blocks. It is
+  always compiled, performs no foreign-function calls, and references no
+  `wayland-client` types, so its unit tests run on every target.
+- Stateful reducers that consume `wayland-client` event streams are gated to
+  `cfg(target_os = "linux")` and build on these helpers.
+
+## Coordinates, scale, and time
+
+Wayland delivers surface-local pointer coordinates as logical (post-scale)
+`f64` values. Callers supply a `scale_factor` (for example from
+`wp_fractional_scale_v1`'s preferred scale divided by 120, or an output's
+integer scale), and these helpers multiply by it to produce the physical
+pixels [`ui-events`] expects.
+
+Reducers built on these helpers take a caller-provided monotonic nanosecond
+timestamp for the pointer [`PointerState`], rather than Wayland's 32-bit
+millisecond event timestamps, so input shares one clock domain with frame
+sampling and timers.
+
+[`PointerState`]: ui_events::pointer::PointerState
+[`ui-events`]: https://docs.rs/ui-events/
+
+<!-- cargo-rdme end -->
+
+## Minimum supported Rust Version (MSRV)
+
+This version of UI Events Wayland has been verified to compile with **Rust 1.85** and later.
+
+Future versions of UI Events Wayland might increase the Rust version requirement.
+It will not be treated as a breaking change and as such can even happen with small patch releases.
+
+<details>
+<summary>Click here if compiling fails.</summary>
+
+As time has passed, some UI Events Wayland dependencies could have released versions with a higher Rust requirement.
+If you encounter a compilation issue due to a dependency and don't want to upgrade your Rust toolchain, then you could downgrade the dependency.
+
+```sh
+# Use the problematic dependency's name and version
+cargo update -p package_name --precise 0.1.1
+```
+
+</details>
+
+## Community
+
+[![Linebender Zulip](https://img.shields.io/badge/Xi%20Zulip-%23general-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/channel/147921-general)
+
+Discussion of UI Events Wayland development happens in the [Linebender Zulip](https://xi.zulipchat.com/), specifically the [#general channel](https://xi.zulipchat.com/#narrow/channel/147921-general).
+All public content can be read without logging in.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+## Contribution
+
+Contributions are welcome by pull request. The [Rust code of conduct] applies.
+Please feel free to add your name to the [AUTHORS] file in any substantive pull request.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be licensed as above, without any additional terms or conditions.
+
+[Rust Code of Conduct]: https://www.rust-lang.org/policies/code-of-conduct
+[AUTHORS]: ./AUTHORS

--- a/ui-events-wayland/README.md
+++ b/ui-events-wayland/README.md
@@ -55,6 +55,14 @@ timestamp for the pointer [`PointerState`], rather than Wayland's 32-bit
 millisecond event timestamps, so input shares one clock domain with frame
 sampling and timers.
 
+## Resolving logical keys
+
+The keyboard reducer resolves the physical key code of every key event with
+no system dependencies. Enabling the non-default `xkb` feature additionally
+links `libxkbcommon` and uses the compositor's keymap to resolve logical key
+values, typed text, and the authoritative modifier set (including the lock
+states and Alt Graph).
+
 [`PointerState`]: ui_events::pointer::PointerState
 [`ui-events`]: https://docs.rs/ui-events/
 

--- a/ui-events-wayland/src/gesture.rs
+++ b/ui-events-wayland/src/gesture.rs
@@ -1,0 +1,286 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Reduces `zwp_pointer_gesture_pinch_v1` event streams into pinch and rotate
+//! [`PointerEvent`]s.
+//!
+//! [`PinchGestureReducer`] mirrors the stateful-reducer pattern of the other
+//! adapters: feed it each touchpad pinch-gesture event together with a
+//! caller-provided monotonic timestamp, and it emits the
+//! [`PointerEvent::Gesture`]s describing the scale and rotation changes.
+//!
+//! Wayland's pinch gesture reports an *absolute* scale relative to the start of
+//! the gesture and a *per-update* clockwise rotation, whereas [`PointerGesture`]
+//! is incremental on both axes. The reducer therefore tracks the previous
+//! absolute scale and emits the per-update scale fraction (see
+//! [`mapping::pinch_scale_fraction`]) alongside the per-update rotation in
+//! radians (see [`mapping::rotation_radians_from_degrees`]). A single pinch
+//! `update` thus yields up to two events — a [`PointerEvent::Gesture`] carrying a
+//! [`PointerGesture::Pinch`] followed by one carrying a
+//! [`PointerGesture::Rotate`] — omitting whichever component did not change.
+//!
+//! The pinch protocol reports only a *relative* logical center, not an absolute
+//! pointer position, so the [`PointerState`] on the emitted events keeps the
+//! default position; correlate it with the `wl_pointer` reducer's position if a
+//! location is needed. Wayland's swipe and hold gestures, and the
+//! relative-pointer protocol, have no [`ui-events`] analog and are out of scope.
+//!
+//! [`PointerState`]: ui_events::pointer::PointerState
+//! [`ui-events`]: https://docs.rs/ui-events/
+
+use ui_events::pointer::{
+    PointerEvent, PointerGesture, PointerGestureEvent, PointerInfo, PointerState, PointerType,
+};
+use wayland_protocols::wp::pointer_gestures::zv1::client::zwp_pointer_gesture_pinch_v1::Event;
+
+use crate::mapping;
+
+/// The [`PointerInfo`] describing a seat's touchpad pinch gesture source.
+///
+/// Touchpad gestures arrive on the seat's `wl_pointer`, so they are reported
+/// against the primary mouse pointer, matching the `wl_pointer` reducer.
+fn gesture_pointer() -> PointerInfo {
+    mapping::primary_pointer_info(PointerType::Mouse)
+}
+
+/// Reduces a `zwp_pointer_gesture_pinch_v1` event stream into pinch and rotate
+/// [`PointerEvent`]s.
+///
+/// Keep one reducer per pinch-gesture object and call [`reduce`] with each
+/// event. See the [module documentation] for the scale, rotation, position, and
+/// timing model.
+///
+/// [`reduce`]: PinchGestureReducer::reduce
+/// [module documentation]: self
+#[derive(Debug)]
+pub struct PinchGestureReducer {
+    /// Absolute pinch scale reported by the most recent `update`, relative to
+    /// the `begin` baseline of `1.0`. Reset to `1.0` whenever a gesture begins
+    /// or ends.
+    last_scale: f64,
+    /// Pointer state stamped onto emitted gesture events.
+    state: PointerState,
+    /// Last caller-provided timestamp, for the monotonicity debug assertion.
+    last_seen_time: Option<u64>,
+}
+
+impl Default for PinchGestureReducer {
+    fn default() -> Self {
+        Self {
+            last_scale: 1.0,
+            state: PointerState::default(),
+            last_seen_time: None,
+        }
+    }
+}
+
+impl PinchGestureReducer {
+    /// Reduce a single pinch-gesture [`Event`] into zero, one, or two
+    /// [`PointerEvent`]s.
+    ///
+    /// `time` is a monotonic nanosecond timestamp in the consumer's clock
+    /// domain, stamped into the [`PointerState`] of every event this call
+    /// produces; Wayland's own 32-bit millisecond event timestamps are
+    /// deliberately not used as the clock. `scale_factor` records the scale of
+    /// the surface the gesture occurred on; it does not affect the pinch
+    /// fraction or rotation, which are dimensionless.
+    ///
+    /// A `begin` or `end` event only updates internal state and returns no
+    /// events. An `update` returns a [`PointerGesture::Pinch`] when the scale
+    /// changed and a [`PointerGesture::Rotate`] when the rotation was non-zero,
+    /// in that order.
+    ///
+    /// `time` must be monotonic across calls; a regression trips a
+    /// `debug_assert!`.
+    pub fn reduce(&mut self, scale_factor: f64, event: &Event, time: u64) -> Vec<PointerEvent> {
+        self.check_time_monotonic(time);
+        self.state.time = time;
+        self.state.scale_factor = scale_factor;
+
+        match event {
+            // `begin` carries a `wl_surface` that cannot be constructed without
+            // a live connection; only the scale baseline reset is needed, so all
+            // fields are ignored.
+            Event::Begin { .. } => {
+                self.last_scale = 1.0;
+                Vec::new()
+            }
+            Event::Update {
+                scale, rotation, ..
+            } => self.update(*scale, *rotation),
+            Event::End { .. } => {
+                self.last_scale = 1.0;
+                Vec::new()
+            }
+            // `Event` is `#[non_exhaustive]`; ignore future additions.
+            _ => Vec::new(),
+        }
+    }
+
+    /// Handle an `update` event: emit the per-update pinch and rotate deltas.
+    fn update(&mut self, scale: f64, rotation: f64) -> Vec<PointerEvent> {
+        let pinch = mapping::pinch_scale_fraction(self.last_scale, scale);
+        // Remember the absolute scale for the next update's delta, ignoring a
+        // degenerate value so one bad update cannot poison the baseline.
+        if scale.is_finite() && scale > 0.0 {
+            self.last_scale = scale;
+        }
+        let rotate = mapping::rotation_radians_from_degrees(rotation);
+
+        let mut events = Vec::new();
+        if pinch != 0.0 {
+            events.push(self.gesture_event(PointerGesture::Pinch(pinch)));
+        }
+        if rotate != 0.0 {
+            events.push(self.gesture_event(PointerGesture::Rotate(rotate)));
+        }
+        events
+    }
+
+    /// Build a [`PointerEvent::Gesture`] for `gesture` with the current state.
+    fn gesture_event(&self, gesture: PointerGesture) -> PointerEvent {
+        PointerEvent::Gesture(PointerGestureEvent {
+            pointer: gesture_pointer(),
+            gesture,
+            state: self.state.clone(),
+        })
+    }
+
+    /// Debug-assert that caller timestamps do not regress.
+    fn check_time_monotonic(&mut self, time: u64) {
+        if let Some(previous) = self.last_seen_time {
+            debug_assert!(
+                time >= previous,
+                "PinchGestureReducer::reduce timestamps must be monotonic nanoseconds"
+            );
+        }
+        self.last_seen_time = Some(time);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build an `update` event. Pinch updates carry no surface, so unlike
+    /// `begin` they can be constructed directly in tests.
+    fn update(scale: f64, rotation: f64) -> Event {
+        Event::Update {
+            time: 0,
+            dx: 0.0,
+            dy: 0.0,
+            scale,
+            rotation,
+        }
+    }
+
+    /// Build an `end` event.
+    fn end() -> Event {
+        Event::End {
+            serial: 0,
+            time: 0,
+            cancelled: 0,
+        }
+    }
+
+    fn pinch_fraction(event: &PointerEvent) -> f32 {
+        match event {
+            PointerEvent::Gesture(PointerGestureEvent {
+                gesture: PointerGesture::Pinch(fraction),
+                ..
+            }) => *fraction,
+            other => panic!("expected a pinch gesture, got {other:?}"),
+        }
+    }
+
+    fn rotation_radians(event: &PointerEvent) -> f32 {
+        match event {
+            PointerEvent::Gesture(PointerGestureEvent {
+                gesture: PointerGesture::Rotate(radians),
+                ..
+            }) => *radians,
+            other => panic!("expected a rotate gesture, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scale_change_emits_pinch_against_begin_baseline() {
+        let mut reducer = PinchGestureReducer::default();
+        // No `begin` is required: the baseline starts at 1.0.
+        let events = reducer.reduce(1.0, &update(1.1, 0.0), 10);
+
+        assert_eq!(events.len(), 1);
+        assert!((pinch_fraction(&events[0]) - 0.1).abs() < 1e-6);
+        // Touchpad gestures are reported against the primary mouse pointer.
+        assert!(events[0].is_primary_pointer());
+    }
+
+    #[test]
+    fn successive_updates_report_incremental_pinch() {
+        let mut reducer = PinchGestureReducer::default();
+        let first = reducer.reduce(1.0, &update(1.1, 0.0), 1);
+        let second = reducer.reduce(1.0, &update(1.21, 0.0), 2);
+
+        assert!((pinch_fraction(&first[0]) - 0.1).abs() < 1e-5);
+        // 1.21 / 1.1 - 1 == 0.1, not 0.21, because the protocol's scale is
+        // absolute relative to `begin`, not per-update.
+        assert!((pinch_fraction(&second[0]) - 0.1).abs() < 1e-5);
+    }
+
+    #[test]
+    fn rotation_is_emitted_as_clockwise_radians() {
+        let mut reducer = PinchGestureReducer::default();
+        let events = reducer.reduce(1.0, &update(1.0, 90.0), 1);
+
+        assert_eq!(events.len(), 1);
+        assert!((rotation_radians(&events[0]) - core::f32::consts::FRAC_PI_2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn scale_and_rotation_emit_pinch_then_rotate() {
+        let mut reducer = PinchGestureReducer::default();
+        let events = reducer.reduce(1.0, &update(1.5, 30.0), 1);
+
+        assert_eq!(events.len(), 2);
+        assert!((pinch_fraction(&events[0]) - 0.5).abs() < 1e-6);
+        assert!((rotation_radians(&events[1]) - 30.0_f32.to_radians()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn noop_update_emits_nothing() {
+        let mut reducer = PinchGestureReducer::default();
+        // Scale unchanged from the 1.0 baseline and no rotation.
+        assert!(reducer.reduce(1.0, &update(1.0, 0.0), 1).is_empty());
+    }
+
+    #[test]
+    fn end_resets_the_scale_baseline() {
+        let mut reducer = PinchGestureReducer::default();
+        let _ = reducer.reduce(1.0, &update(2.0, 0.0), 1);
+        // End the gesture; the next gesture's first update is relative to 1.0.
+        let _ = reducer.reduce(1.0, &end(), 2);
+        let events = reducer.reduce(1.0, &update(1.1, 0.0), 3);
+
+        assert!((pinch_fraction(&events[0]) - 0.1).abs() < 1e-6);
+    }
+
+    #[test]
+    fn state_carries_time_and_scale_factor() {
+        let mut reducer = PinchGestureReducer::default();
+        let events = reducer.reduce(2.0, &update(1.1, 0.0), 42);
+
+        let PointerEvent::Gesture(gesture) = &events[0] else {
+            panic!("expected a gesture, got {:?}", events[0]);
+        };
+        assert_eq!(gesture.state.time, 42);
+        assert_eq!(gesture.state.scale_factor, 2.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "timestamps must be monotonic nanoseconds")]
+    fn non_monotonic_time_panics_in_debug() {
+        let mut reducer = PinchGestureReducer::default();
+        let _ = reducer.reduce(1.0, &update(1.0, 0.0), 2_000);
+        let _ = reducer.reduce(1.0, &update(1.0, 0.0), 1_000);
+    }
+}

--- a/ui-events-wayland/src/gesture.rs
+++ b/ui-events-wayland/src/gesture.rs
@@ -28,6 +28,8 @@
 //! [`PointerState`]: ui_events::pointer::PointerState
 //! [`ui-events`]: https://docs.rs/ui-events/
 
+use alloc::vec::Vec;
+
 use ui_events::pointer::{
     PointerEvent, PointerGesture, PointerGestureEvent, PointerInfo, PointerState, PointerType,
 };

--- a/ui-events-wayland/src/keyboard.rs
+++ b/ui-events-wayland/src/keyboard.rs
@@ -58,6 +58,7 @@
 //! [`NamedKey::Unidentified`]: ui_events::keyboard::NamedKey::Unidentified
 //! [`Location::Standard`]: ui_events::keyboard::Location::Standard
 
+use alloc::vec::Vec;
 #[cfg(feature = "xkb")]
 use std::fs::File;
 #[cfg(feature = "xkb")]

--- a/ui-events-wayland/src/keyboard.rs
+++ b/ui-events-wayland/src/keyboard.rs
@@ -20,7 +20,17 @@
 //! composition, all of which need the keymap, so the [`KeyboardEvent`]'s `key` is
 //! [`Key::Named`]\([`NamedKey::Unidentified`]) and its `location` is
 //! [`Location::Standard`] in this tier. Resolving them, and typed text, is the
-//! job of the `xkb` feature.
+//! job of the `xkb` feature described below.
+//!
+//! ## Logical keys with the `xkb` feature
+//!
+//! Enabling the `xkb` feature links `libxkbcommon` and resolves the logical key
+//! from the compositor's keymap. The `keymap` event compiles an XKB keymap; each
+//! key's scancode (offset by `8` to its xkb keycode) is then translated to a
+//! [`Key`] — a [`Key::Character`] carrying the typed text, or a [`Key::Named`]
+//! for an action key — and the [`KeyboardEvent`]'s `location` is derived from its
+//! physical [`Code`]. Until a `keymap` event arrives, the keymap-less behavior
+//! above still applies.
 //!
 //! ## Modifiers
 //!
@@ -30,8 +40,9 @@
 //! layout-independent [`Code`]s — assembling the modifier set through
 //! [`mapping::modifiers_from_bools`]. A modifier stays active while either its
 //! left or right key is held. The lock states (Caps Lock, Num Lock) and the
-//! Alt Graph distinction are defined by the keymap and resolved only under the
-//! `xkb` feature.
+//! Alt Graph distinction are defined by the keymap, so with the `xkb` feature
+//! the keymap interprets the `modifiers` event directly and yields the
+//! authoritative set including those lock states and Alt Graph.
 //!
 //! ## Focus and repeat
 //!
@@ -43,12 +54,22 @@
 //! [`KeyboardEventReducer::repeat_info`] for a consumer that drives key repeat.
 //!
 //! [`Key::Named`]: ui_events::keyboard::Key::Named
+//! [`Key::Character`]: ui_events::keyboard::Key::Character
 //! [`NamedKey::Unidentified`]: ui_events::keyboard::NamedKey::Unidentified
 //! [`Location::Standard`]: ui_events::keyboard::Location::Standard
 
+#[cfg(feature = "xkb")]
+use std::fs::File;
+#[cfg(feature = "xkb")]
+use std::os::unix::io::OwnedFd;
+
 use ui_events::keyboard::{Code, Key, KeyState, KeyboardEvent, Location, Modifiers, NamedKey};
 use wayland_client::WEnum;
+#[cfg(feature = "xkb")]
+use wayland_client::protocol::wl_keyboard::KeymapFormat;
 use wayland_client::protocol::wl_keyboard::{Event, KeyState as WlKeyState};
+#[cfg(feature = "xkb")]
+use xkbcommon::xkb;
 
 use crate::mapping;
 
@@ -86,14 +107,18 @@ pub struct KeyboardEventReducer {
     pressed: Vec<u32>,
     /// The most recent key-repeat parameters from `repeat_info`, if any.
     repeat_info: Option<RepeatInfo>,
+    /// The XKB keymap state, present only under the `xkb` feature.
+    #[cfg(feature = "xkb")]
+    xkb: XkbState,
 }
 
 impl KeyboardEventReducer {
     /// Reduce a single `wl_keyboard` [`Event`] into an optional [`KeyboardEvent`].
     ///
     /// Only `key` events translate to a [`KeyboardEvent`]; `enter`, `leave`, and
-    /// `repeat_info` update internal state and return `None`, and the `keymap`
-    /// and (without the keymap, opaque) `modifiers` events are ignored.
+    /// `repeat_info` update internal state and return `None`. The `keymap` and
+    /// `modifiers` events feed the keymap state under the `xkb` feature and are
+    /// otherwise ignored (the modifier set is then tracked from physical keys).
     pub fn reduce(&mut self, event: &Event) -> Option<KeyboardEvent> {
         match event {
             Event::Key { key, state, .. } => self.key(*key, *state),
@@ -112,10 +137,29 @@ impl KeyboardEventReducer {
                 });
                 None
             }
-            // The keymap is consumed only under the `xkb` feature; without it the
-            // raw scancodes are interpreted directly. The `modifiers` bitmask is
-            // opaque without the keymap, so physical modifier keys are tracked
-            // instead (see `modifiers`).
+            // Under the `xkb` feature the keymap drives logical-key and
+            // authoritative-modifier resolution.
+            #[cfg(feature = "xkb")]
+            Event::Keymap { format, fd, .. } => {
+                self.xkb.set_keymap(*format, fd);
+                None
+            }
+            #[cfg(feature = "xkb")]
+            Event::Modifiers {
+                mods_depressed,
+                mods_latched,
+                mods_locked,
+                group,
+                ..
+            } => {
+                self.xkb
+                    .update_modifiers(*mods_depressed, *mods_latched, *mods_locked, *group);
+                None
+            }
+            // Without the keymap (no `xkb` feature) the `keymap` event is unused
+            // and the `modifiers` bitmask is opaque, so physical modifier keys
+            // are tracked instead (see `modifiers`).
+            #[cfg(not(feature = "xkb"))]
             Event::Keymap { .. } | Event::Modifiers { .. } => None,
             // `wl_keyboard::Event` is `#[non_exhaustive]`; ignore future additions.
             _ => None,
@@ -135,6 +179,13 @@ impl KeyboardEventReducer {
     /// before any [`KeyboardEvent`] is produced. Lock states and the Alt Graph
     /// distinction are resolved only under the `xkb` feature.
     pub fn modifiers(&self) -> Modifiers {
+        // With a keymap, the modifier set — including the lock states and Alt
+        // Graph — comes from the authoritative xkb state.
+        #[cfg(feature = "xkb")]
+        if let Some(modifiers) = self.xkb.modifiers() {
+            return modifiers;
+        }
+        // Otherwise derive it from the physical modifier keys held.
         let (mut ctrl, mut alt, mut shift, mut meta) = (false, false, false, false);
         for &scancode in &self.pressed {
             match mapping::code_from_evdev_scancode(scancode) {
@@ -168,11 +219,19 @@ impl KeyboardEventReducer {
             self.pressed.retain(|&held| held != scancode);
         }
 
+        let code = mapping::code_from_evdev_scancode(scancode);
+        // The logical key and location are resolved from the keymap under the
+        // `xkb` feature; otherwise only the physical code is known.
+        #[cfg(feature = "xkb")]
+        let (key, location) = self.xkb.resolve(scancode, code);
+        #[cfg(not(feature = "xkb"))]
+        let (key, location) = (Key::Named(NamedKey::Unidentified), Location::Standard);
+
         Some(KeyboardEvent {
             state: key_state,
-            key: Key::Named(NamedKey::Unidentified),
-            code: mapping::code_from_evdev_scancode(scancode),
-            location: Location::Standard,
+            key,
+            code,
+            location,
             modifiers: self.modifiers(),
             repeat,
             is_composing: false,
@@ -201,6 +260,114 @@ impl KeyboardEventReducer {
     /// Handle a `leave` event: clear the pressed-key state.
     fn leave(&mut self) {
         self.pressed.clear();
+    }
+}
+
+/// The XKB keymap state backing logical-key and modifier resolution.
+///
+/// Present only under the `xkb` feature. It owns an xkb context and, once a
+/// `keymap` event has arrived, the derived keyboard state that the `modifiers`
+/// events keep current.
+#[cfg(feature = "xkb")]
+struct XkbState {
+    /// The xkb context used to compile keymaps.
+    context: xkb::Context,
+    /// The keyboard state for the current keymap, once one has been received.
+    state: Option<xkb::State>,
+}
+
+#[cfg(feature = "xkb")]
+impl Default for XkbState {
+    fn default() -> Self {
+        Self {
+            context: xkb::Context::new(xkb::CONTEXT_NO_FLAGS),
+            state: None,
+        }
+    }
+}
+
+#[cfg(feature = "xkb")]
+impl core::fmt::Debug for XkbState {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("XkbState")
+            .field("keymap_loaded", &self.state.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "xkb")]
+impl XkbState {
+    /// Compile the keymap from a `wl_keyboard` `keymap` event and build the
+    /// keyboard state from it.
+    ///
+    /// Only the XKB v1 text format is understood; any other format is ignored,
+    /// as is a keymap that fails to compile (the previous state is kept). The
+    /// file descriptor is duplicated and read rather than memory-mapped, so the
+    /// reducer needs no `unsafe` and leaves the caller's descriptor undisturbed.
+    fn set_keymap(&mut self, format: WEnum<KeymapFormat>, fd: &OwnedFd) {
+        if !matches!(format, WEnum::Value(KeymapFormat::XkbV1)) {
+            return;
+        }
+        let Ok(fd) = fd.try_clone() else {
+            return;
+        };
+        let mut file = File::from(fd);
+        if let Some(keymap) = xkb::Keymap::new_from_file(
+            &self.context,
+            &mut file,
+            xkb::KEYMAP_FORMAT_TEXT_V1,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        ) {
+            self.state = Some(xkb::State::new(&keymap));
+        }
+    }
+
+    /// Apply a `wl_keyboard` `modifiers` event to the keyboard state.
+    ///
+    /// Wayland serializes the modifier and layout state, so the masks are fed in
+    /// directly with [`State::update_mask`]; `group` is the effective (locked)
+    /// layout.
+    ///
+    /// [`State::update_mask`]: xkb::State::update_mask
+    fn update_modifiers(&mut self, depressed: u32, latched: u32, locked: u32, group: u32) {
+        if let Some(state) = self.state.as_mut() {
+            state.update_mask(depressed, latched, locked, 0, 0, group);
+        }
+    }
+
+    /// The modifier set derived from the keymap state, or `None` if no keymap
+    /// has arrived yet.
+    fn modifiers(&self) -> Option<Modifiers> {
+        let state = self.state.as_ref()?;
+        Some(mapping::modifiers_from_active_mods(
+            state.mod_name_is_active(xkb::MOD_NAME_CTRL, xkb::STATE_MODS_EFFECTIVE),
+            state.mod_name_is_active(xkb::MOD_NAME_ALT, xkb::STATE_MODS_EFFECTIVE),
+            state.mod_name_is_active(xkb::MOD_NAME_SHIFT, xkb::STATE_MODS_EFFECTIVE),
+            state.mod_name_is_active(xkb::MOD_NAME_LOGO, xkb::STATE_MODS_EFFECTIVE),
+            state.mod_name_is_active(xkb::MOD_NAME_CAPS, xkb::STATE_MODS_EFFECTIVE),
+            state.mod_name_is_active(xkb::MOD_NAME_NUM, xkb::STATE_MODS_EFFECTIVE),
+            state.mod_name_is_active(xkb::MOD_NAME_ISO_LEVEL3_SHIFT, xkb::STATE_MODS_EFFECTIVE),
+        ))
+    }
+
+    /// Resolve a key's logical [`Key`] and [`Location`] from the keymap state.
+    ///
+    /// Without a keymap yet, this returns the keymap-less result, so the
+    /// behavior matches a build without the feature until a keymap arrives.
+    fn resolve(&self, scancode: u32, code: Code) -> (Key, Location) {
+        match self.state.as_ref() {
+            Some(state) => {
+                // X11/XKB keycodes are the evdev scancodes offset by 8.
+                let keycode = xkb::Keycode::new(scancode + 8);
+                let keysym = state.key_get_one_sym(keycode);
+                let text = state.key_get_utf8(keycode);
+                (
+                    mapping::key_from_keysym(keysym.raw(), &text),
+                    mapping::location_from_code(code),
+                )
+            }
+            None => (Key::Named(NamedKey::Unidentified), Location::Standard),
+        }
     }
 }
 
@@ -374,5 +541,101 @@ mod tests {
             .reduce(&key_event(0, WlKeyState::Pressed))
             .expect("an unmapped key should still translate");
         assert_eq!(event.code, Code::Unidentified);
+    }
+
+    /// Compile a US-layout keymap state, or `None` if the system has no XKB
+    /// keymap data (in which case the `xkb` integration tests skip).
+    #[cfg(feature = "xkb")]
+    fn us_keymap_state() -> Option<xkb::State> {
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let keymap = xkb::Keymap::new_from_names(
+            &context,
+            "",
+            "",
+            "us",
+            "",
+            None,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        )?;
+        Some(xkb::State::new(&keymap))
+    }
+
+    #[cfg(feature = "xkb")]
+    #[test]
+    fn xkb_resolves_typed_text() {
+        let Some(state) = us_keymap_state() else {
+            return;
+        };
+        let mut reducer = KeyboardEventReducer::default();
+        reducer.xkb.state = Some(state);
+
+        // `KEY_A` produces the character 'a' on a US layout.
+        let event = reducer
+            .reduce(&key_event(KEY_A, WlKeyState::Pressed))
+            .expect("a key press should translate");
+        assert_eq!(event.key, Key::Character("a".into()));
+        assert_eq!(event.code, Code::KeyA);
+        assert_eq!(event.location, Location::Standard);
+    }
+
+    #[cfg(feature = "xkb")]
+    #[test]
+    fn xkb_resolves_named_key_and_side_location() {
+        let Some(state) = us_keymap_state() else {
+            return;
+        };
+        let mut reducer = KeyboardEventReducer::default();
+        reducer.xkb.state = Some(state);
+
+        // Enter is a named key even though xkb reports a control character for it.
+        const KEY_ENTER: u32 = 28;
+        let enter = reducer
+            .reduce(&key_event(KEY_ENTER, WlKeyState::Pressed))
+            .expect("enter should translate");
+        assert_eq!(enter.key, Key::Named(NamedKey::Enter));
+
+        // Left Shift resolves to the named modifier at the left location.
+        let shift = reducer
+            .reduce(&key_event(KEY_LEFTSHIFT, WlKeyState::Pressed))
+            .expect("shift should translate");
+        assert_eq!(shift.key, Key::Named(NamedKey::Shift));
+        assert_eq!(shift.location, Location::Left);
+    }
+
+    #[cfg(feature = "xkb")]
+    #[test]
+    fn xkb_modifiers_come_from_keymap_state() {
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let Some(keymap) = xkb::Keymap::new_from_names(
+            &context,
+            "",
+            "",
+            "us",
+            "",
+            None,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        ) else {
+            return;
+        };
+        let shift_index = keymap.mod_get_index(xkb::MOD_NAME_SHIFT);
+        if shift_index == xkb::MOD_INVALID {
+            return;
+        }
+        let mut reducer = KeyboardEventReducer::default();
+        reducer.xkb.state = Some(xkb::State::new(&keymap));
+
+        // The keymap state starts with no active modifiers.
+        assert_eq!(reducer.modifiers(), Modifiers::empty());
+
+        // Depressing the Shift modifier (as the compositor serializes it through
+        // the `modifiers` event) makes the keymap-derived set report Shift.
+        reducer.reduce(&Event::Modifiers {
+            serial: 0,
+            mods_depressed: 1_u32 << shift_index,
+            mods_latched: 0,
+            mods_locked: 0,
+            group: 0,
+        });
+        assert!(reducer.modifiers().shift());
     }
 }

--- a/ui-events-wayland/src/keyboard.rs
+++ b/ui-events-wayland/src/keyboard.rs
@@ -1,0 +1,378 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Reduces `wl_keyboard` event streams into [`KeyboardEvent`]s.
+//!
+//! [`KeyboardEventReducer`] mirrors the stateful-reducer pattern of the other
+//! adapters: feed it each `wl_keyboard` event for a seat's keyboard and it
+//! tracks the focused keyboard state, returning a [`KeyboardEvent`] for each key
+//! press and release.
+//!
+//! ## Physical keys without a keymap
+//!
+//! This reducer resolves the *physical* key. Each key's evdev scancode is mapped
+//! to its W3C [`Code`] through [`mapping::code_from_evdev_scancode`], and the key
+//! state to [`KeyState::Down`] or [`KeyState::Up`]. The `repeated` key state
+//! added in `wl_keyboard` version 10 is reported as a [`KeyState::Down`] with the
+//! event's `repeat` flag set; the reducer does not otherwise synthesize repeats.
+//!
+//! The *logical* key value depends on the active layout, dead keys, and
+//! composition, all of which need the keymap, so the [`KeyboardEvent`]'s `key` is
+//! [`Key::Named`]\([`NamedKey::Unidentified`]) and its `location` is
+//! [`Location::Standard`] in this tier. Resolving them, and typed text, is the
+//! job of the `xkb` feature.
+//!
+//! ## Modifiers
+//!
+//! Without the keymap the `wl_keyboard` `modifiers` event is an opaque bitmask,
+//! so the reducer ignores it and instead tracks the physical modifier keys it
+//! sees pressed and released — Control, Alt, Shift, and Meta, by their
+//! layout-independent [`Code`]s — assembling the modifier set through
+//! [`mapping::modifiers_from_bools`]. A modifier stays active while either its
+//! left or right key is held. The lock states (Caps Lock, Num Lock) and the
+//! Alt Graph distinction are defined by the keymap and resolved only under the
+//! `xkb` feature.
+//!
+//! ## Focus and repeat
+//!
+//! A focus `enter` lists the keys already logically down; the reducer seeds its
+//! pressed-key state from them so the modifier set is correct from the first
+//! event, but emits nothing (the protocol advises against emulating presses from
+//! that list). A `leave` clears the state. The `keymap` event is used only under
+//! the `xkb` feature, and the `repeat_info` parameters are surfaced through
+//! [`KeyboardEventReducer::repeat_info`] for a consumer that drives key repeat.
+//!
+//! [`Key::Named`]: ui_events::keyboard::Key::Named
+//! [`NamedKey::Unidentified`]: ui_events::keyboard::NamedKey::Unidentified
+//! [`Location::Standard`]: ui_events::keyboard::Location::Standard
+
+use ui_events::keyboard::{Code, Key, KeyState, KeyboardEvent, Location, Modifiers, NamedKey};
+use wayland_client::WEnum;
+use wayland_client::protocol::wl_keyboard::{Event, KeyState as WlKeyState};
+
+use crate::mapping;
+
+/// Key-repeat parameters reported by `wl_keyboard`'s `repeat_info` event.
+///
+/// The compositor advertises how the seat's keyboard should repeat a held key.
+/// The reducer does not synthesize repeat events itself — that needs a timer in
+/// the consumer's event loop — so it surfaces these parameters for the consumer
+/// to drive repetition (or to defer to a compositor that takes over repetition,
+/// which it signals by advertising a `rate` of `0`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RepeatInfo {
+    /// The repeat rate in keys per second. A rate of `0` disables key repeat.
+    pub rate: i32,
+    /// The delay in milliseconds from a key going down until it starts
+    /// repeating.
+    pub delay: i32,
+}
+
+/// Reduces a `wl_keyboard` event stream into [`KeyboardEvent`]s.
+///
+/// Keep one reducer per seat keyboard and call [`reduce`] with each
+/// `wl_keyboard` event. See the [module documentation] for what this tier does
+/// and does not resolve.
+///
+/// [`reduce`]: KeyboardEventReducer::reduce
+/// [module documentation]: self
+#[derive(Debug, Default)]
+pub struct KeyboardEventReducer {
+    /// The evdev scancodes currently logically down.
+    ///
+    /// Seeded from a focus `enter`, updated by each `key` event, and cleared on
+    /// `leave`. The modifier set is derived from this state, so a left/right
+    /// modifier pair stays active until both keys are released.
+    pressed: Vec<u32>,
+    /// The most recent key-repeat parameters from `repeat_info`, if any.
+    repeat_info: Option<RepeatInfo>,
+}
+
+impl KeyboardEventReducer {
+    /// Reduce a single `wl_keyboard` [`Event`] into an optional [`KeyboardEvent`].
+    ///
+    /// Only `key` events translate to a [`KeyboardEvent`]; `enter`, `leave`, and
+    /// `repeat_info` update internal state and return `None`, and the `keymap`
+    /// and (without the keymap, opaque) `modifiers` events are ignored.
+    pub fn reduce(&mut self, event: &Event) -> Option<KeyboardEvent> {
+        match event {
+            Event::Key { key, state, .. } => self.key(*key, *state),
+            Event::Enter { keys, .. } => {
+                self.enter(keys);
+                None
+            }
+            Event::Leave { .. } => {
+                self.leave();
+                None
+            }
+            Event::RepeatInfo { rate, delay } => {
+                self.repeat_info = Some(RepeatInfo {
+                    rate: *rate,
+                    delay: *delay,
+                });
+                None
+            }
+            // The keymap is consumed only under the `xkb` feature; without it the
+            // raw scancodes are interpreted directly. The `modifiers` bitmask is
+            // opaque without the keymap, so physical modifier keys are tracked
+            // instead (see `modifiers`).
+            Event::Keymap { .. } | Event::Modifiers { .. } => None,
+            // `wl_keyboard::Event` is `#[non_exhaustive]`; ignore future additions.
+            _ => None,
+        }
+    }
+
+    /// The most recently advertised key-repeat parameters, if the compositor has
+    /// sent a `repeat_info` event.
+    pub fn repeat_info(&self) -> Option<RepeatInfo> {
+        self.repeat_info
+    }
+
+    /// The current modifier set, derived from the physical modifier keys held.
+    ///
+    /// This reflects the same state stamped into each emitted [`KeyboardEvent`].
+    /// It is useful right after a focus `enter`, whose held keys seed the state
+    /// before any [`KeyboardEvent`] is produced. Lock states and the Alt Graph
+    /// distinction are resolved only under the `xkb` feature.
+    pub fn modifiers(&self) -> Modifiers {
+        let (mut ctrl, mut alt, mut shift, mut meta) = (false, false, false, false);
+        for &scancode in &self.pressed {
+            match mapping::code_from_evdev_scancode(scancode) {
+                Code::ControlLeft | Code::ControlRight => ctrl = true,
+                Code::AltLeft | Code::AltRight => alt = true,
+                Code::ShiftLeft | Code::ShiftRight => shift = true,
+                Code::MetaLeft | Code::MetaRight => meta = true,
+                _ => {}
+            }
+        }
+        mapping::modifiers_from_bools(ctrl, alt, shift, meta)
+    }
+
+    /// Handle a `key` event: update the pressed-key state and build the event.
+    fn key(&mut self, scancode: u32, state: WEnum<WlKeyState>) -> Option<KeyboardEvent> {
+        let (key_state, repeat) = match state {
+            WEnum::Value(WlKeyState::Pressed) => (KeyState::Down, false),
+            // The `repeated` state (version 10) means "still pressed", flagged as
+            // a repeat.
+            WEnum::Value(WlKeyState::Repeated) => (KeyState::Down, true),
+            WEnum::Value(WlKeyState::Released) => (KeyState::Up, false),
+            // Unknown key state; ignore.
+            _ => return None,
+        };
+
+        if key_state == KeyState::Down {
+            if !self.pressed.contains(&scancode) {
+                self.pressed.push(scancode);
+            }
+        } else {
+            self.pressed.retain(|&held| held != scancode);
+        }
+
+        Some(KeyboardEvent {
+            state: key_state,
+            key: Key::Named(NamedKey::Unidentified),
+            code: mapping::code_from_evdev_scancode(scancode),
+            location: Location::Standard,
+            modifiers: self.modifiers(),
+            repeat,
+            is_composing: false,
+        })
+    }
+
+    /// Seed the pressed-key state from a focus `enter`'s key array.
+    ///
+    /// `keys` is the wire array of currently-pressed evdev scancodes, each
+    /// encoded as a little-endian `u32`. Trailing bytes that do not form a whole
+    /// `u32` are ignored.
+    ///
+    /// This takes the key bytes rather than the `wl_surface`, so the
+    /// surface-independent logic stays unit-testable without a live connection
+    /// (a `wl_surface` cannot be constructed without one).
+    fn enter(&mut self, keys: &[u8]) {
+        self.pressed.clear();
+        for chunk in keys.chunks_exact(4) {
+            let scancode = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            if !self.pressed.contains(&scancode) {
+                self.pressed.push(scancode);
+            }
+        }
+    }
+
+    /// Handle a `leave` event: clear the pressed-key state.
+    fn leave(&mut self) {
+        self.pressed.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `KEY_A` from `linux/input-event-codes.h`.
+    const KEY_A: u32 = 30;
+    /// `KEY_LEFTCTRL`.
+    const KEY_LEFTCTRL: u32 = 29;
+    /// `KEY_LEFTSHIFT`.
+    const KEY_LEFTSHIFT: u32 = 42;
+    /// `KEY_RIGHTSHIFT`.
+    const KEY_RIGHTSHIFT: u32 = 54;
+
+    fn key_event(scancode: u32, state: WlKeyState) -> Event {
+        Event::Key {
+            serial: 0,
+            time: 0,
+            key: scancode,
+            state: WEnum::Value(state),
+        }
+    }
+
+    #[test]
+    fn key_press_maps_physical_code_and_down_state() {
+        let mut reducer = KeyboardEventReducer::default();
+        let event = reducer
+            .reduce(&key_event(KEY_A, WlKeyState::Pressed))
+            .expect("a key press should translate");
+
+        assert_eq!(event.state, KeyState::Down);
+        assert_eq!(event.code, Code::KeyA);
+        assert_eq!(event.key, Key::Named(NamedKey::Unidentified));
+        assert_eq!(event.location, Location::Standard);
+        assert!(!event.repeat);
+        assert!(!event.is_composing);
+        assert_eq!(event.modifiers, Modifiers::empty());
+    }
+
+    #[test]
+    fn key_release_maps_up_state() {
+        let mut reducer = KeyboardEventReducer::default();
+        let _ = reducer.reduce(&key_event(KEY_A, WlKeyState::Pressed));
+        let event = reducer
+            .reduce(&key_event(KEY_A, WlKeyState::Released))
+            .expect("a key release should translate");
+
+        assert_eq!(event.state, KeyState::Up);
+        assert_eq!(event.code, Code::KeyA);
+    }
+
+    #[test]
+    fn repeated_key_state_sets_repeat_flag() {
+        let mut reducer = KeyboardEventReducer::default();
+        let _ = reducer.reduce(&key_event(KEY_A, WlKeyState::Pressed));
+        let event = reducer
+            .reduce(&key_event(KEY_A, WlKeyState::Repeated))
+            .expect("a repeated key should translate");
+
+        assert_eq!(event.state, KeyState::Down);
+        assert!(event.repeat);
+    }
+
+    #[test]
+    fn modifiers_track_physical_modifier_keys() {
+        let mut reducer = KeyboardEventReducer::default();
+
+        let ctrl_down = reducer
+            .reduce(&key_event(KEY_LEFTCTRL, WlKeyState::Pressed))
+            .expect("control down should translate");
+        // The set includes the modifier currently being pressed.
+        assert!(ctrl_down.modifiers.ctrl());
+        assert_eq!(ctrl_down.code, Code::ControlLeft);
+
+        let a_down = reducer
+            .reduce(&key_event(KEY_A, WlKeyState::Pressed))
+            .expect("a down should translate");
+        assert!(a_down.modifiers.ctrl());
+
+        let ctrl_up = reducer
+            .reduce(&key_event(KEY_LEFTCTRL, WlKeyState::Released))
+            .expect("control up should translate");
+        assert!(!ctrl_up.modifiers.ctrl());
+    }
+
+    #[test]
+    fn left_and_right_modifier_stay_active_until_both_released() {
+        let mut reducer = KeyboardEventReducer::default();
+        let _ = reducer.reduce(&key_event(KEY_LEFTSHIFT, WlKeyState::Pressed));
+        let _ = reducer.reduce(&key_event(KEY_RIGHTSHIFT, WlKeyState::Pressed));
+
+        let left_up = reducer
+            .reduce(&key_event(KEY_LEFTSHIFT, WlKeyState::Released))
+            .expect("left shift up should translate");
+        // The right shift is still held, so shift stays active.
+        assert!(left_up.modifiers.shift());
+
+        let right_up = reducer
+            .reduce(&key_event(KEY_RIGHTSHIFT, WlKeyState::Released))
+            .expect("right shift up should translate");
+        assert!(!right_up.modifiers.shift());
+    }
+
+    #[test]
+    fn enter_seeds_modifier_state_from_pressed_keys() {
+        let mut reducer = KeyboardEventReducer::default();
+        // The focus `enter` reports Left Control already held, as a
+        // little-endian u32 scancode array.
+        reducer.enter(&KEY_LEFTCTRL.to_le_bytes());
+
+        assert!(reducer.modifiers().ctrl());
+        // A subsequent key carries the seeded modifier state.
+        let a_down = reducer
+            .reduce(&key_event(KEY_A, WlKeyState::Pressed))
+            .expect("a down should translate");
+        assert!(a_down.modifiers.ctrl());
+    }
+
+    #[test]
+    fn leave_clears_modifier_state() {
+        let mut reducer = KeyboardEventReducer::default();
+        reducer.enter(&KEY_LEFTCTRL.to_le_bytes());
+        reducer.leave();
+
+        assert_eq!(reducer.modifiers(), Modifiers::empty());
+    }
+
+    #[test]
+    fn repeat_info_is_exposed_and_emits_nothing() {
+        let mut reducer = KeyboardEventReducer::default();
+        assert_eq!(reducer.repeat_info(), None);
+
+        let emitted = reducer.reduce(&Event::RepeatInfo {
+            rate: 25,
+            delay: 600,
+        });
+
+        assert_eq!(emitted, None);
+        assert_eq!(
+            reducer.repeat_info(),
+            Some(RepeatInfo {
+                rate: 25,
+                delay: 600
+            })
+        );
+    }
+
+    #[test]
+    fn opaque_modifiers_event_is_ignored() {
+        let mut reducer = KeyboardEventReducer::default();
+        // The bitmask is meaningless without a keymap, so it must neither change
+        // the tracked modifier state nor emit an event.
+        let emitted = reducer.reduce(&Event::Modifiers {
+            serial: 0,
+            mods_depressed: u32::MAX,
+            mods_latched: 0,
+            mods_locked: 0,
+            group: 0,
+        });
+
+        assert_eq!(emitted, None);
+        assert_eq!(reducer.modifiers(), Modifiers::empty());
+    }
+
+    #[test]
+    fn unmapped_scancode_is_unidentified() {
+        let mut reducer = KeyboardEventReducer::default();
+        let event = reducer
+            .reduce(&key_event(0, WlKeyState::Pressed))
+            .expect("an unmapped key should still translate");
+        assert_eq!(event.code, Code::Unidentified);
+    }
+}

--- a/ui-events-wayland/src/lib.rs
+++ b/ui-events-wayland/src/lib.rs
@@ -1,0 +1,48 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Bridges Wayland input into the [`ui-events`] model.
+//!
+//! This crate is Linux-only in practice. The `wayland-client` protocol bindings
+//! it builds on are depended upon only on `cfg(target_os = "linux")` targets,
+//! and the stateful reducers that consume them are gated the same way. On every
+//! other target the crate compiles to an essentially empty library, so it can
+//! live in a cross-platform workspace without pulling in platform dependencies.
+//!
+//! ## Architecture
+//!
+//! - [`mapping`] holds platform-neutral, value-based conversions from Wayland
+//!   input primitives (evdev button codes, surface-local coordinates, axis
+//!   values, modifier booleans) into [`ui-events`] building blocks. It is
+//!   always compiled, performs no foreign-function calls, and references no
+//!   `wayland-client` types, so its unit tests run on every target.
+//! - Stateful reducers that consume `wayland-client` event streams are gated to
+//!   `cfg(target_os = "linux")` and build on these helpers.
+//!
+//! ## Coordinates, scale, and time
+//!
+//! Wayland delivers surface-local pointer coordinates as logical (post-scale)
+//! `f64` values. Callers supply a `scale_factor` (for example from
+//! `wp_fractional_scale_v1`'s preferred scale divided by 120, or an output's
+//! integer scale), and these helpers multiply by it to produce the physical
+//! pixels [`ui-events`] expects.
+//!
+//! Reducers built on these helpers take a caller-provided monotonic nanosecond
+//! timestamp for the pointer [`PointerState`], rather than Wayland's 32-bit
+//! millisecond event timestamps, so input shares one clock domain with frame
+//! sampling and timers.
+//!
+//! [`PointerState`]: ui_events::pointer::PointerState
+//! [`ui-events`]: https://docs.rs/ui-events/
+
+// LINEBENDER LINT SET - lib.rs - v3
+// See https://linebender.org/wiki/canonical-lints/
+// These lints shouldn't apply to examples or tests.
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+// These lints shouldn't apply to examples.
+#![warn(clippy::print_stdout, clippy::print_stderr)]
+// Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
+#![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
+// END LINEBENDER LINT SET
+
+pub mod mapping;

--- a/ui-events-wayland/src/lib.rs
+++ b/ui-events-wayland/src/lib.rs
@@ -40,6 +40,13 @@
 //! values, typed text, and the authoritative modifier set (including the lock
 //! states and Alt Graph).
 //!
+//! ## Feature policy
+//!
+//! - `std` is enabled by default.
+//! - `no_std` builds require `libm`, which supplies the trigonometry the tablet
+//!   and touch mapping use.
+//! - `xkb` reads the compositor keymap through `std::fs`, so it implies `std`.
+//!
 //! [`PointerState`]: ui_events::pointer::PointerState
 //! [`ui-events`]: https://docs.rs/ui-events/
 
@@ -60,6 +67,11 @@ extern crate alloc;
 // descriptor through `std::fs`.
 #[cfg(feature = "xkb")]
 extern crate std;
+
+// `libm` is only used by `no_std` builds (the `mapping` trigonometry); keep it
+// referenced so a `std + libm` build does not trip `unused_crate_dependencies`.
+#[cfg(all(feature = "std", feature = "libm"))]
+use libm as _;
 
 pub mod mapping;
 

--- a/ui-events-wayland/src/lib.rs
+++ b/ui-events-wayland/src/lib.rs
@@ -46,3 +46,6 @@
 // END LINEBENDER LINT SET
 
 pub mod mapping;
+
+#[cfg(target_os = "linux")]
+pub mod pointer;

--- a/ui-events-wayland/src/lib.rs
+++ b/ui-events-wayland/src/lib.rs
@@ -65,6 +65,9 @@ pub mod keyboard;
 pub mod pointer;
 
 #[cfg(target_os = "linux")]
+pub mod seat;
+
+#[cfg(target_os = "linux")]
 pub mod tablet;
 
 #[cfg(target_os = "linux")]

--- a/ui-events-wayland/src/lib.rs
+++ b/ui-events-wayland/src/lib.rs
@@ -32,6 +32,14 @@
 //! millisecond event timestamps, so input shares one clock domain with frame
 //! sampling and timers.
 //!
+//! ## Resolving logical keys
+//!
+//! The keyboard reducer resolves the physical key code of every key event with
+//! no system dependencies. Enabling the non-default `xkb` feature additionally
+//! links `libxkbcommon` and uses the compositor's keymap to resolve logical key
+//! values, typed text, and the authoritative modifier set (including the lock
+//! states and Alt Graph).
+//!
 //! [`PointerState`]: ui_events::pointer::PointerState
 //! [`ui-events`]: https://docs.rs/ui-events/
 

--- a/ui-events-wayland/src/lib.rs
+++ b/ui-events-wayland/src/lib.rs
@@ -51,6 +51,9 @@ pub mod mapping;
 pub mod gesture;
 
 #[cfg(target_os = "linux")]
+pub mod keyboard;
+
+#[cfg(target_os = "linux")]
 pub mod pointer;
 
 #[cfg(target_os = "linux")]

--- a/ui-events-wayland/src/lib.rs
+++ b/ui-events-wayland/src/lib.rs
@@ -48,6 +48,9 @@
 pub mod mapping;
 
 #[cfg(target_os = "linux")]
+pub mod gesture;
+
+#[cfg(target_os = "linux")]
 pub mod pointer;
 
 #[cfg(target_os = "linux")]

--- a/ui-events-wayland/src/lib.rs
+++ b/ui-events-wayland/src/lib.rs
@@ -54,4 +54,7 @@ pub mod gesture;
 pub mod pointer;
 
 #[cfg(target_os = "linux")]
+pub mod tablet;
+
+#[cfg(target_os = "linux")]
 pub mod touch;

--- a/ui-events-wayland/src/lib.rs
+++ b/ui-events-wayland/src/lib.rs
@@ -49,3 +49,6 @@ pub mod mapping;
 
 #[cfg(target_os = "linux")]
 pub mod pointer;
+
+#[cfg(target_os = "linux")]
+pub mod touch;

--- a/ui-events-wayland/src/lib.rs
+++ b/ui-events-wayland/src/lib.rs
@@ -52,6 +52,14 @@
 // Targeting e.g. 32-bit means structs containing usize can give false positives for 64-bit.
 #![cfg_attr(target_pointer_width = "64", warn(clippy::trivially_copy_pass_by_ref))]
 // END LINEBENDER LINT SET
+#![no_std]
+
+extern crate alloc;
+
+// `std` is required only by the `xkb` feature, which reads the keymap file
+// descriptor through `std::fs`.
+#[cfg(feature = "xkb")]
+extern crate std;
 
 pub mod mapping;
 

--- a/ui-events-wayland/src/mapping.rs
+++ b/ui-events-wayland/src/mapping.rs
@@ -19,7 +19,9 @@
 use dpi::PhysicalPosition;
 use ui_events::ScrollDelta;
 use ui_events::keyboard::Modifiers;
-use ui_events::pointer::{PointerButton, PointerId, PointerInfo, PointerType};
+use ui_events::pointer::{
+    ContactGeometry, PointerButton, PointerId, PointerInfo, PointerOrientation, PointerType,
+};
 
 // evdev pointer button codes from `linux/input-event-codes.h`.
 const BTN_LEFT: u32 = 0x110;
@@ -224,6 +226,69 @@ pub fn modifiers_from_bools(ctrl: bool, alt: bool, shift: bool, meta: bool) -> M
     m
 }
 
+/// Build a [`PointerInfo`] for a touch contact, reserving [`PointerId::PRIMARY`]
+/// for the primary contact.
+///
+/// `wl_touch` identifies each contact with a small non-negative integer that is
+/// unique among the contacts currently down. The contact whose id equals
+/// `primary_id` — conventionally the lowest active id, mirroring the primary
+/// pointer in the web backend — is mapped to [`PointerId::PRIMARY`]. Every other
+/// contact is offset through [`pointer_info_from_platform_id`] so it cannot
+/// collide with the reserved primary id.
+pub fn touch_pointer_info(id: u64, primary_id: u64) -> PointerInfo {
+    if id == primary_id {
+        primary_pointer_info(PointerType::Touch)
+    } else {
+        pointer_info_from_platform_id(PointerType::Touch, id)
+    }
+}
+
+/// Convert a `wl_touch` contact ellipse into a [`ContactGeometry`].
+///
+/// `wl_touch::shape` reports the lengths of the major and minor axes of the
+/// ellipse approximating the contact, in surface-local (logical) coordinates.
+/// Wayland aligns the major axis with the surface y-axis at the zero
+/// orientation, so the major-axis length becomes the geometry's `height` and the
+/// minor-axis length its `width`; the major-axis direction is reported
+/// separately as the azimuth of [`touch_orientation_from_degrees`]. Both lengths
+/// are multiplied by `scale_factor` to produce physical pixels.
+///
+/// A non-positive or non-finite axis length or `scale_factor` falls back to a
+/// single physical pixel, matching the [`ContactGeometry`] default.
+pub fn contact_geometry_from_shape(major: f64, minor: f64, scale_factor: f64) -> ContactGeometry {
+    let scale_factor = positive_finite_or(scale_factor, 1.0);
+    ContactGeometry {
+        width: positive_finite_or(minor * scale_factor, 1.0),
+        height: positive_finite_or(major * scale_factor, 1.0),
+    }
+}
+
+/// Convert a `wl_touch` contact orientation into a [`PointerOrientation`].
+///
+/// `wl_touch::orientation` reports the clockwise angle, in degrees, between the
+/// contact ellipse's major axis and the positive surface y-axis. A touch contact
+/// lies flat against the surface, so the altitude is always perpendicular
+/// (`π/2`); the angle is folded into the azimuth, which is `0` along the positive
+/// x-axis and `π/2` along the positive y-axis. An orientation of `0°` therefore
+/// yields the default [`PointerOrientation`].
+///
+/// A non-finite angle falls back to the default orientation.
+pub fn touch_orientation_from_degrees(orientation_deg: f64) -> PointerOrientation {
+    if !orientation_deg.is_finite() {
+        return PointerOrientation::default();
+    }
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Wayland reports orientation as f64 degrees; ui-events stores azimuth as f32"
+    )]
+    let azimuth = (core::f32::consts::FRAC_PI_2 + (orientation_deg as f32).to_radians())
+        .rem_euclid(core::f32::consts::TAU);
+    PointerOrientation {
+        altitude: core::f32::consts::FRAC_PI_2,
+        azimuth,
+    }
+}
+
 #[inline]
 fn finite_or(value: f64, fallback: f64) -> f64 {
     if value.is_finite() { value } else { fallback }
@@ -390,5 +455,56 @@ mod tests {
         assert!(!mods.alt());
         assert!(mods.shift());
         assert!(!mods.meta());
+    }
+
+    #[test]
+    fn touch_primary_contact_is_primary_pointer() {
+        let info = touch_pointer_info(3, 3);
+        assert!(info.is_primary_pointer());
+        assert_eq!(info.pointer_type, PointerType::Touch);
+    }
+
+    #[test]
+    fn touch_non_primary_contact_is_offset() {
+        let info = touch_pointer_info(3, 1);
+        assert!(!info.is_primary_pointer());
+        assert_eq!(info.pointer_type, PointerType::Touch);
+        assert_eq!(info.pointer_id, PointerId::new(3 + POINTER_ID_OFFSET));
+    }
+
+    #[test]
+    fn shape_maps_minor_to_width_and_major_to_height_scaled() {
+        let geometry = contact_geometry_from_shape(10.0, 4.0, 2.0);
+        assert_eq!(geometry.width, 8.0);
+        assert_eq!(geometry.height, 20.0);
+    }
+
+    #[test]
+    fn shape_sanitizes_degenerate_axes() {
+        let geometry = contact_geometry_from_shape(0.0, f64::NAN, 1.0);
+        assert_eq!(geometry.width, 1.0);
+        assert_eq!(geometry.height, 1.0);
+    }
+
+    #[test]
+    fn orientation_zero_degrees_is_default() {
+        let orientation = touch_orientation_from_degrees(0.0);
+        assert_eq!(orientation.altitude, core::f32::consts::FRAC_PI_2);
+        assert!((orientation.azimuth - core::f32::consts::FRAC_PI_2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn orientation_rotates_azimuth_clockwise_from_y_axis() {
+        // 90° clockwise from the +y axis puts the major axis along azimuth π.
+        let orientation = touch_orientation_from_degrees(90.0);
+        assert!((orientation.azimuth - core::f32::consts::PI).abs() < 1e-5);
+    }
+
+    #[test]
+    fn orientation_non_finite_is_default() {
+        assert_eq!(
+            touch_orientation_from_degrees(f64::INFINITY),
+            PointerOrientation::default()
+        );
     }
 }

--- a/ui-events-wayland/src/mapping.rs
+++ b/ui-events-wayland/src/mapping.rs
@@ -18,7 +18,7 @@
 
 use dpi::PhysicalPosition;
 use ui_events::ScrollDelta;
-use ui_events::keyboard::{Code, Modifiers};
+use ui_events::keyboard::{Code, Key, Location, Modifiers, NamedKey};
 use ui_events::pointer::{
     ContactGeometry, PointerButton, PointerId, PointerInfo, PointerOrientation, PointerType,
 };
@@ -419,6 +419,336 @@ pub fn code_from_evdev_scancode(scancode: u32) -> Code {
         194 => Code::F24,
         _ => Code::Unidentified,
     }
+}
+
+// XKB keysym values for the named (non-typing) keys, from
+// `xkbcommon/xkbcommon-keysyms.h`. These are the frozen X11 keysym constants
+// the `xkb` keymap resolves keys to; the typing keys resolve instead to Unicode
+// or Latin-1 keysyms and carry their text, so they are not listed here.
+const KEY_ISO_LEVEL3_SHIFT: u32 = 0xfe03;
+const KEY_ISO_LEVEL3_LATCH: u32 = 0xfe04;
+const KEY_ISO_LEVEL3_LOCK: u32 = 0xfe05;
+const KEY_ISO_NEXT_GROUP: u32 = 0xfe08;
+const KEY_ISO_PREV_GROUP: u32 = 0xfe0a;
+const KEY_ISO_FIRST_GROUP: u32 = 0xfe0c;
+const KEY_ISO_LAST_GROUP: u32 = 0xfe0e;
+const KEY_ISO_LEFT_TAB: u32 = 0xfe20;
+const KEY_ISO_ENTER: u32 = 0xfe34;
+const KEY_BACKSPACE: u32 = 0xff08;
+const KEY_TAB: u32 = 0xff09;
+const KEY_CLEAR: u32 = 0xff0b;
+const KEY_RETURN: u32 = 0xff0d;
+const KEY_PAUSE: u32 = 0xff13;
+const KEY_SCROLL_LOCK: u32 = 0xff14;
+const KEY_SYS_REQ: u32 = 0xff15;
+const KEY_ESCAPE: u32 = 0xff1b;
+const KEY_MULTI_KEY: u32 = 0xff20;
+const KEY_KANJI: u32 = 0xff21;
+const KEY_MUHENKAN: u32 = 0xff22;
+const KEY_HENKAN_MODE: u32 = 0xff23;
+const KEY_ROMAJI: u32 = 0xff24;
+const KEY_HIRAGANA: u32 = 0xff25;
+const KEY_KATAKANA: u32 = 0xff26;
+const KEY_HIRAGANA_KATAKANA: u32 = 0xff27;
+const KEY_ZENKAKU: u32 = 0xff28;
+const KEY_HANKAKU: u32 = 0xff29;
+const KEY_ZENKAKU_HANKAKU: u32 = 0xff2a;
+const KEY_KANA_LOCK: u32 = 0xff2d;
+const KEY_EISU_TOGGLE: u32 = 0xff30;
+const KEY_HANGUL: u32 = 0xff31;
+const KEY_HANGUL_HANJA: u32 = 0xff34;
+const KEY_HOME: u32 = 0xff50;
+const KEY_LEFT: u32 = 0xff51;
+const KEY_UP: u32 = 0xff52;
+const KEY_RIGHT: u32 = 0xff53;
+const KEY_DOWN: u32 = 0xff54;
+const KEY_PAGE_UP: u32 = 0xff55;
+const KEY_PAGE_DOWN: u32 = 0xff56;
+const KEY_END: u32 = 0xff57;
+const KEY_SELECT: u32 = 0xff60;
+const KEY_PRINT: u32 = 0xff61;
+const KEY_EXECUTE: u32 = 0xff62;
+const KEY_INSERT: u32 = 0xff63;
+const KEY_UNDO: u32 = 0xff65;
+const KEY_REDO: u32 = 0xff66;
+const KEY_MENU: u32 = 0xff67;
+const KEY_FIND: u32 = 0xff68;
+const KEY_CANCEL: u32 = 0xff69;
+const KEY_HELP: u32 = 0xff6a;
+const KEY_BREAK: u32 = 0xff6b;
+const KEY_MODE_SWITCH: u32 = 0xff7e;
+const KEY_NUM_LOCK: u32 = 0xff7f;
+const KEY_KP_TAB: u32 = 0xff89;
+const KEY_KP_ENTER: u32 = 0xff8d;
+const KEY_KP_F1: u32 = 0xff91;
+const KEY_KP_F2: u32 = 0xff92;
+const KEY_KP_F3: u32 = 0xff93;
+const KEY_KP_F4: u32 = 0xff94;
+const KEY_KP_HOME: u32 = 0xff95;
+const KEY_KP_LEFT: u32 = 0xff96;
+const KEY_KP_UP: u32 = 0xff97;
+const KEY_KP_RIGHT: u32 = 0xff98;
+const KEY_KP_DOWN: u32 = 0xff99;
+const KEY_KP_PAGE_UP: u32 = 0xff9a;
+const KEY_KP_PAGE_DOWN: u32 = 0xff9b;
+const KEY_KP_END: u32 = 0xff9c;
+const KEY_KP_INSERT: u32 = 0xff9e;
+const KEY_KP_DELETE: u32 = 0xff9f;
+const KEY_F1: u32 = 0xffbe;
+const KEY_F2: u32 = 0xffbf;
+const KEY_F3: u32 = 0xffc0;
+const KEY_F4: u32 = 0xffc1;
+const KEY_F5: u32 = 0xffc2;
+const KEY_F6: u32 = 0xffc3;
+const KEY_F7: u32 = 0xffc4;
+const KEY_F8: u32 = 0xffc5;
+const KEY_F9: u32 = 0xffc6;
+const KEY_F10: u32 = 0xffc7;
+const KEY_F11: u32 = 0xffc8;
+const KEY_F12: u32 = 0xffc9;
+const KEY_F13: u32 = 0xffca;
+const KEY_F14: u32 = 0xffcb;
+const KEY_F15: u32 = 0xffcc;
+const KEY_F16: u32 = 0xffcd;
+const KEY_F17: u32 = 0xffce;
+const KEY_F18: u32 = 0xffcf;
+const KEY_F19: u32 = 0xffd0;
+const KEY_F20: u32 = 0xffd1;
+const KEY_F21: u32 = 0xffd2;
+const KEY_F22: u32 = 0xffd3;
+const KEY_F23: u32 = 0xffd4;
+const KEY_F24: u32 = 0xffd5;
+const KEY_F25: u32 = 0xffd6;
+const KEY_F26: u32 = 0xffd7;
+const KEY_F27: u32 = 0xffd8;
+const KEY_F28: u32 = 0xffd9;
+const KEY_F29: u32 = 0xffda;
+const KEY_F30: u32 = 0xffdb;
+const KEY_F31: u32 = 0xffdc;
+const KEY_F32: u32 = 0xffdd;
+const KEY_F33: u32 = 0xffde;
+const KEY_F34: u32 = 0xffdf;
+const KEY_F35: u32 = 0xffe0;
+const KEY_SHIFT_L: u32 = 0xffe1;
+const KEY_SHIFT_R: u32 = 0xffe2;
+const KEY_CONTROL_L: u32 = 0xffe3;
+const KEY_CONTROL_R: u32 = 0xffe4;
+const KEY_CAPS_LOCK: u32 = 0xffe5;
+const KEY_META_L: u32 = 0xffe7;
+const KEY_META_R: u32 = 0xffe8;
+const KEY_ALT_L: u32 = 0xffe9;
+const KEY_ALT_R: u32 = 0xffea;
+const KEY_SUPER_L: u32 = 0xffeb;
+const KEY_SUPER_R: u32 = 0xffec;
+const KEY_HYPER_L: u32 = 0xffed;
+const KEY_HYPER_R: u32 = 0xffee;
+const KEY_DELETE: u32 = 0xffff;
+
+/// Map an XKB keysym to a W3C [`NamedKey`], if it names a non-typing key.
+///
+/// The `xkb` keymap resolves each key press to a keysym. The typing keys
+/// (letters, digits, punctuation, and space) resolve to Unicode or Latin-1
+/// keysyms and are better represented by the text they produce, so they return
+/// `None` here and [`key_from_keysym`] falls back to that text. The remaining
+/// keys — editing, navigation, function, modifier, lock, input-method, and
+/// numeric-keypad action keys — map to their [`NamedKey`].
+///
+/// The keypad digit and operator keysyms also return `None`: with Num Lock on
+/// they produce their character, and with it off the compositor reports the
+/// matching navigation keysym (for example `KP_Left`) instead, which is named
+/// here. Obscure multimedia, browser, and power keysyms return `None` too,
+/// mirroring the keys [`code_from_evdev_scancode`] leaves [`Code::Unidentified`].
+///
+/// The Linux "super"/Windows-logo key and the legacy Hyper and Meta keys all
+/// map to [`NamedKey::Meta`], the W3C name for the operating-system key.
+pub fn named_key_from_keysym(keysym: u32) -> Option<NamedKey> {
+    Some(match keysym {
+        KEY_BACKSPACE => NamedKey::Backspace,
+        KEY_TAB | KEY_KP_TAB | KEY_ISO_LEFT_TAB => NamedKey::Tab,
+        KEY_CLEAR => NamedKey::Clear,
+        KEY_RETURN | KEY_KP_ENTER | KEY_ISO_ENTER => NamedKey::Enter,
+        KEY_PAUSE | KEY_BREAK => NamedKey::Pause,
+        KEY_SCROLL_LOCK => NamedKey::ScrollLock,
+        KEY_SYS_REQ | KEY_PRINT => NamedKey::PrintScreen,
+        KEY_ESCAPE => NamedKey::Escape,
+        KEY_DELETE | KEY_KP_DELETE => NamedKey::Delete,
+
+        // Input-method and layout-group keys.
+        KEY_MULTI_KEY => NamedKey::Compose,
+        KEY_MODE_SWITCH => NamedKey::ModeChange,
+        KEY_ISO_NEXT_GROUP => NamedKey::GroupNext,
+        KEY_ISO_PREV_GROUP => NamedKey::GroupPrevious,
+        KEY_ISO_FIRST_GROUP => NamedKey::GroupFirst,
+        KEY_ISO_LAST_GROUP => NamedKey::GroupLast,
+
+        // Japanese and Korean input keys.
+        KEY_KANJI => NamedKey::KanjiMode,
+        KEY_MUHENKAN => NamedKey::NonConvert,
+        KEY_HENKAN_MODE => NamedKey::Convert,
+        KEY_ROMAJI => NamedKey::Romaji,
+        KEY_HIRAGANA => NamedKey::Hiragana,
+        KEY_KATAKANA => NamedKey::Katakana,
+        KEY_HIRAGANA_KATAKANA => NamedKey::HiraganaKatakana,
+        KEY_ZENKAKU => NamedKey::Zenkaku,
+        KEY_HANKAKU => NamedKey::Hankaku,
+        KEY_ZENKAKU_HANKAKU => NamedKey::ZenkakuHankaku,
+        KEY_KANA_LOCK => NamedKey::KanaMode,
+        KEY_EISU_TOGGLE => NamedKey::Alphanumeric,
+        KEY_HANGUL => NamedKey::HangulMode,
+        KEY_HANGUL_HANJA => NamedKey::HanjaMode,
+
+        // Navigation and editing, including the numeric-keypad equivalents the
+        // keymap reports when Num Lock is off.
+        KEY_HOME | KEY_KP_HOME => NamedKey::Home,
+        KEY_LEFT | KEY_KP_LEFT => NamedKey::ArrowLeft,
+        KEY_UP | KEY_KP_UP => NamedKey::ArrowUp,
+        KEY_RIGHT | KEY_KP_RIGHT => NamedKey::ArrowRight,
+        KEY_DOWN | KEY_KP_DOWN => NamedKey::ArrowDown,
+        KEY_PAGE_UP | KEY_KP_PAGE_UP => NamedKey::PageUp,
+        KEY_PAGE_DOWN | KEY_KP_PAGE_DOWN => NamedKey::PageDown,
+        KEY_END | KEY_KP_END => NamedKey::End,
+        KEY_INSERT | KEY_KP_INSERT => NamedKey::Insert,
+        KEY_SELECT => NamedKey::Select,
+        KEY_EXECUTE => NamedKey::Execute,
+        KEY_UNDO => NamedKey::Undo,
+        KEY_REDO => NamedKey::Redo,
+        KEY_MENU => NamedKey::ContextMenu,
+        KEY_FIND => NamedKey::Find,
+        KEY_CANCEL => NamedKey::Cancel,
+        KEY_HELP => NamedKey::Help,
+        KEY_NUM_LOCK => NamedKey::NumLock,
+
+        // Function keys, including the keypad's F1–F4.
+        KEY_F1 | KEY_KP_F1 => NamedKey::F1,
+        KEY_F2 | KEY_KP_F2 => NamedKey::F2,
+        KEY_F3 | KEY_KP_F3 => NamedKey::F3,
+        KEY_F4 | KEY_KP_F4 => NamedKey::F4,
+        KEY_F5 => NamedKey::F5,
+        KEY_F6 => NamedKey::F6,
+        KEY_F7 => NamedKey::F7,
+        KEY_F8 => NamedKey::F8,
+        KEY_F9 => NamedKey::F9,
+        KEY_F10 => NamedKey::F10,
+        KEY_F11 => NamedKey::F11,
+        KEY_F12 => NamedKey::F12,
+        KEY_F13 => NamedKey::F13,
+        KEY_F14 => NamedKey::F14,
+        KEY_F15 => NamedKey::F15,
+        KEY_F16 => NamedKey::F16,
+        KEY_F17 => NamedKey::F17,
+        KEY_F18 => NamedKey::F18,
+        KEY_F19 => NamedKey::F19,
+        KEY_F20 => NamedKey::F20,
+        KEY_F21 => NamedKey::F21,
+        KEY_F22 => NamedKey::F22,
+        KEY_F23 => NamedKey::F23,
+        KEY_F24 => NamedKey::F24,
+        KEY_F25 => NamedKey::F25,
+        KEY_F26 => NamedKey::F26,
+        KEY_F27 => NamedKey::F27,
+        KEY_F28 => NamedKey::F28,
+        KEY_F29 => NamedKey::F29,
+        KEY_F30 => NamedKey::F30,
+        KEY_F31 => NamedKey::F31,
+        KEY_F32 => NamedKey::F32,
+        KEY_F33 => NamedKey::F33,
+        KEY_F34 => NamedKey::F34,
+        KEY_F35 => NamedKey::F35,
+
+        // Modifier keys.
+        KEY_SHIFT_L | KEY_SHIFT_R => NamedKey::Shift,
+        KEY_CONTROL_L | KEY_CONTROL_R => NamedKey::Control,
+        KEY_CAPS_LOCK => NamedKey::CapsLock,
+        KEY_ALT_L | KEY_ALT_R => NamedKey::Alt,
+        KEY_META_L | KEY_META_R | KEY_SUPER_L | KEY_SUPER_R | KEY_HYPER_L | KEY_HYPER_R => {
+            NamedKey::Meta
+        }
+        KEY_ISO_LEVEL3_SHIFT | KEY_ISO_LEVEL3_LATCH | KEY_ISO_LEVEL3_LOCK => NamedKey::AltGraph,
+
+        _ => return None,
+    })
+}
+
+/// Resolve an XKB keysym and its typed text into a logical [`Key`].
+///
+/// The keysym is matched against [`named_key_from_keysym`] first, so the control
+/// keys whose text would be a control character (such as Enter or Escape) are
+/// named rather than treated as text. Otherwise non-empty `text` containing no
+/// control characters becomes a [`Key::Character`] — this covers letters,
+/// digits, punctuation, and the space key, which has no named-key form. Anything
+/// else resolves to [`NamedKey::Unidentified`].
+///
+/// `text` is the string from `xkb_state_key_get_utf8` for the key in the current
+/// keyboard state.
+pub fn key_from_keysym(keysym: u32, text: &str) -> Key {
+    if let Some(named) = named_key_from_keysym(keysym) {
+        return Key::Named(named);
+    }
+    if !text.is_empty() && !text.chars().any(char::is_control) {
+        return Key::Character(text.into());
+    }
+    Key::Named(NamedKey::Unidentified)
+}
+
+/// Map a physical [`Code`] to its W3C keyboard [`Location`].
+///
+/// The left and right variants of the modifier keys map to [`Location::Left`]
+/// and [`Location::Right`], the numeric-keypad keys to [`Location::Numpad`], and
+/// everything else — including `NumLock`, which the specification keeps on the
+/// standard keyboard — to [`Location::Standard`].
+pub fn location_from_code(code: Code) -> Location {
+    match code {
+        Code::ShiftLeft | Code::ControlLeft | Code::AltLeft | Code::MetaLeft => Location::Left,
+        Code::ShiftRight | Code::ControlRight | Code::AltRight | Code::MetaRight => Location::Right,
+        Code::Numpad0
+        | Code::Numpad1
+        | Code::Numpad2
+        | Code::Numpad3
+        | Code::Numpad4
+        | Code::Numpad5
+        | Code::Numpad6
+        | Code::Numpad7
+        | Code::Numpad8
+        | Code::Numpad9
+        | Code::NumpadAdd
+        | Code::NumpadSubtract
+        | Code::NumpadMultiply
+        | Code::NumpadDivide
+        | Code::NumpadDecimal
+        | Code::NumpadComma
+        | Code::NumpadEnter
+        | Code::NumpadEqual => Location::Numpad,
+        _ => Location::Standard,
+    }
+}
+
+/// Assemble a [`Modifiers`] set from the individually active XKB modifiers.
+///
+/// This is the keymap-aware counterpart to [`modifiers_from_bools`]: it adds the
+/// lock states and the Alt Graph (ISO level-3) modifier, which the keymap
+/// resolves but the bare key stream cannot. Each argument is whether the
+/// corresponding modifier is active, as reported by
+/// `xkb_state_mod_name_is_active`.
+pub fn modifiers_from_active_mods(
+    ctrl: bool,
+    alt: bool,
+    shift: bool,
+    meta: bool,
+    caps_lock: bool,
+    num_lock: bool,
+    alt_graph: bool,
+) -> Modifiers {
+    let mut m = modifiers_from_bools(ctrl, alt, shift, meta);
+    if caps_lock {
+        m.insert(Modifiers::CAPS_LOCK);
+    }
+    if num_lock {
+        m.insert(Modifiers::NUM_LOCK);
+    }
+    if alt_graph {
+        m.insert(Modifiers::ALT_GRAPH);
+    }
+    m
 }
 
 /// Build a [`PointerInfo`] for a touch contact, reserving [`PointerId::PRIMARY`]
@@ -1051,5 +1381,117 @@ mod tests {
         let orientation = pointer_orientation_from_tilt_degrees(f64::NAN, f64::INFINITY);
         assert!((orientation.altitude - core::f32::consts::FRAC_PI_2).abs() < 1e-5);
         assert!((orientation.azimuth - core::f32::consts::FRAC_PI_2).abs() < 1e-5);
+    }
+
+    #[test]
+    fn keysym_named_keys_map_to_expected_named_keys() {
+        assert_eq!(named_key_from_keysym(KEY_ESCAPE), Some(NamedKey::Escape));
+        assert_eq!(named_key_from_keysym(KEY_RETURN), Some(NamedKey::Enter));
+        assert_eq!(named_key_from_keysym(KEY_KP_ENTER), Some(NamedKey::Enter));
+        assert_eq!(
+            named_key_from_keysym(KEY_BACKSPACE),
+            Some(NamedKey::Backspace)
+        );
+        assert_eq!(named_key_from_keysym(KEY_F1), Some(NamedKey::F1));
+        assert_eq!(named_key_from_keysym(KEY_F24), Some(NamedKey::F24));
+        assert_eq!(named_key_from_keysym(KEY_LEFT), Some(NamedKey::ArrowLeft));
+        // The numpad arrow (Num Lock off) resolves to the same logical key.
+        assert_eq!(
+            named_key_from_keysym(KEY_KP_LEFT),
+            Some(NamedKey::ArrowLeft)
+        );
+        assert_eq!(named_key_from_keysym(KEY_SHIFT_L), Some(NamedKey::Shift));
+        assert_eq!(named_key_from_keysym(KEY_SHIFT_R), Some(NamedKey::Shift));
+        // The super/logo and legacy meta keys all fold into Meta.
+        assert_eq!(named_key_from_keysym(KEY_SUPER_L), Some(NamedKey::Meta));
+        assert_eq!(named_key_from_keysym(KEY_META_R), Some(NamedKey::Meta));
+        assert_eq!(
+            named_key_from_keysym(KEY_ISO_LEVEL3_SHIFT),
+            Some(NamedKey::AltGraph)
+        );
+        assert_eq!(named_key_from_keysym(KEY_NUM_LOCK), Some(NamedKey::NumLock));
+    }
+
+    #[test]
+    fn typing_keysyms_are_not_named() {
+        // Letters, digits, and space resolve to text, not a named key.
+        assert_eq!(named_key_from_keysym(0x61), None); // 'a'
+        assert_eq!(named_key_from_keysym(0x41), None); // 'A'
+        assert_eq!(named_key_from_keysym(0x31), None); // '1'
+        assert_eq!(named_key_from_keysym(0x20), None); // space
+        assert_eq!(named_key_from_keysym(0), None); // NoSymbol
+    }
+
+    #[test]
+    fn key_from_keysym_prefers_named_then_text() {
+        // A named key wins even though xkb hands back a control character for it.
+        assert_eq!(
+            key_from_keysym(KEY_ESCAPE, "\u{1b}"),
+            Key::Named(NamedKey::Escape)
+        );
+        // Printable text becomes a character key.
+        assert_eq!(key_from_keysym(0x61, "a"), Key::Character("a".into()));
+        // Space has no named-key form, so it comes through as its character.
+        assert_eq!(key_from_keysym(0x20, " "), Key::Character(" ".into()));
+        // Bare control text with no named key is unidentified, not a character.
+        assert_eq!(
+            key_from_keysym(0, "\u{1b}"),
+            Key::Named(NamedKey::Unidentified)
+        );
+        assert_eq!(key_from_keysym(0, ""), Key::Named(NamedKey::Unidentified));
+    }
+
+    #[test]
+    fn location_from_code_classifies_sides_and_numpad() {
+        assert_eq!(location_from_code(Code::ShiftLeft), Location::Left);
+        assert_eq!(location_from_code(Code::ControlRight), Location::Right);
+        assert_eq!(location_from_code(Code::MetaLeft), Location::Left);
+        assert_eq!(location_from_code(Code::Numpad5), Location::Numpad);
+        assert_eq!(location_from_code(Code::NumpadEnter), Location::Numpad);
+        assert_eq!(location_from_code(Code::KeyA), Location::Standard);
+        // Num Lock itself stays on the standard keyboard.
+        assert_eq!(location_from_code(Code::NumLock), Location::Standard);
+    }
+
+    #[test]
+    fn modifiers_from_active_mods_adds_locks_and_alt_graph() {
+        let mods = modifiers_from_active_mods(true, false, true, false, true, false, true);
+        assert!(mods.contains(Modifiers::CONTROL));
+        assert!(mods.contains(Modifiers::SHIFT));
+        assert!(mods.contains(Modifiers::CAPS_LOCK));
+        assert!(mods.contains(Modifiers::ALT_GRAPH));
+        assert!(!mods.contains(Modifiers::ALT));
+        assert!(!mods.contains(Modifiers::META));
+        assert!(!mods.contains(Modifiers::NUM_LOCK));
+    }
+
+    /// Cross-check the hand-copied keysym constants against the libxkbcommon
+    /// definitions, so a transcription error in the table is caught. This needs
+    /// the `xkbcommon` crate, so it is gated to a Linux build with the `xkb`
+    /// feature.
+    #[cfg(all(target_os = "linux", feature = "xkb"))]
+    #[test]
+    fn keysym_constants_match_xkbcommon() {
+        use xkbcommon::xkb::keysyms;
+        assert_eq!(KEY_BACKSPACE, keysyms::KEY_BackSpace);
+        assert_eq!(KEY_TAB, keysyms::KEY_Tab);
+        assert_eq!(KEY_RETURN, keysyms::KEY_Return);
+        assert_eq!(KEY_ESCAPE, keysyms::KEY_Escape);
+        assert_eq!(KEY_DELETE, keysyms::KEY_Delete);
+        assert_eq!(KEY_HOME, keysyms::KEY_Home);
+        assert_eq!(KEY_LEFT, keysyms::KEY_Left);
+        assert_eq!(KEY_END, keysyms::KEY_End);
+        assert_eq!(KEY_KP_ENTER, keysyms::KEY_KP_Enter);
+        assert_eq!(KEY_KP_LEFT, keysyms::KEY_KP_Left);
+        assert_eq!(KEY_NUM_LOCK, keysyms::KEY_Num_Lock);
+        assert_eq!(KEY_F1, keysyms::KEY_F1);
+        assert_eq!(KEY_F12, keysyms::KEY_F12);
+        assert_eq!(KEY_F35, keysyms::KEY_F35);
+        assert_eq!(KEY_SHIFT_L, keysyms::KEY_Shift_L);
+        assert_eq!(KEY_CONTROL_R, keysyms::KEY_Control_R);
+        assert_eq!(KEY_SUPER_L, keysyms::KEY_Super_L);
+        assert_eq!(KEY_ALT_R, keysyms::KEY_Alt_R);
+        assert_eq!(KEY_ISO_LEVEL3_SHIFT, keysyms::KEY_ISO_Level3_Shift);
+        assert_eq!(KEY_ISO_LEFT_TAB, keysyms::KEY_ISO_Left_Tab);
     }
 }

--- a/ui-events-wayland/src/mapping.rs
+++ b/ui-events-wayland/src/mapping.rs
@@ -1,0 +1,394 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Platform-neutral conversions from Wayland input primitives into
+//! [`ui-events`] building blocks.
+//!
+//! Every function here operates on plain values — evdev codes, `f64`
+//! coordinates, axis values, and modifier booleans — and never references
+//! `wayland-client` types or performs any foreign-function calls. That keeps
+//! the module compilable and unit-testable on every target, including the
+//! `no_std` cross-compilation and Miri jobs, and is what keeps [`ui-events`]
+//! and `dpi` used on non-Linux targets.
+//!
+//! The Linux-gated reducers convert `wayland-client` event streams into the
+//! arguments these helpers accept.
+//!
+//! [`ui-events`]: https://docs.rs/ui-events/
+
+use dpi::PhysicalPosition;
+use ui_events::ScrollDelta;
+use ui_events::keyboard::Modifiers;
+use ui_events::pointer::{PointerButton, PointerId, PointerInfo, PointerType};
+
+// evdev pointer button codes from `linux/input-event-codes.h`.
+const BTN_LEFT: u32 = 0x110;
+const BTN_RIGHT: u32 = 0x111;
+const BTN_MIDDLE: u32 = 0x112;
+const BTN_SIDE: u32 = 0x113;
+const BTN_EXTRA: u32 = 0x114;
+const BTN_FORWARD: u32 = 0x115;
+const BTN_BACK: u32 = 0x116;
+const BTN_TASK: u32 = 0x117;
+
+/// Map an evdev pointer button code to a [`PointerButton`].
+///
+/// The codes are the `BTN_*` values from `linux/input-event-codes.h` that
+/// `wl_pointer` reports in its button events:
+///
+/// - `BTN_LEFT` → [`PointerButton::Primary`]
+/// - `BTN_RIGHT` → [`PointerButton::Secondary`]
+/// - `BTN_MIDDLE` → [`PointerButton::Auxiliary`]
+/// - `BTN_SIDE` → [`PointerButton::X1`]
+/// - `BTN_EXTRA` → [`PointerButton::X2`]
+/// - `BTN_FORWARD` → [`PointerButton::B7`]
+/// - `BTN_BACK` → [`PointerButton::B8`]
+/// - `BTN_TASK` → [`PointerButton::B9`]
+///
+/// `BTN_FORWARD`, `BTN_BACK`, and `BTN_TASK` have no dedicated `ui-events`
+/// button, so they map into the generic `B7`..`B9` range rather than being
+/// conflated with the [`PointerButton::X1`]/[`PointerButton::X2`] side buttons.
+/// Any other code returns `None`.
+pub fn pointer_button_from_evdev(code: u32) -> Option<PointerButton> {
+    Some(match code {
+        BTN_LEFT => PointerButton::Primary,
+        BTN_RIGHT => PointerButton::Secondary,
+        BTN_MIDDLE => PointerButton::Auxiliary,
+        BTN_SIDE => PointerButton::X1,
+        BTN_EXTRA => PointerButton::X2,
+        BTN_FORWARD => PointerButton::B7,
+        BTN_BACK => PointerButton::B8,
+        BTN_TASK => PointerButton::B9,
+        _ => return None,
+    })
+}
+
+/// Convert Wayland surface-local logical coordinates to physical pixels.
+///
+/// `wl_pointer` and `wl_touch` deliver surface-local coordinates as logical
+/// (post-scale) `f64` values; the bindings already convert the on-the-wire
+/// 24.8 fixed-point representation to `f64`, so no fixed-point conversion is
+/// needed here. Multiplying by `scale_factor` yields the physical pixels that
+/// [`PointerState`] positions use.
+///
+/// Non-finite coordinates are treated as `0.0`, and a non-positive or
+/// non-finite `scale_factor` falls back to `1.0`.
+///
+/// [`PointerState`]: ui_events::pointer::PointerState
+pub fn physical_position_from_logical(x: f64, y: f64, scale_factor: f64) -> PhysicalPosition<f64> {
+    let scale_factor = positive_finite_or(scale_factor, 1.0);
+    PhysicalPosition {
+        x: finite_or(x, 0.0) * scale_factor,
+        y: finite_or(y, 0.0) * scale_factor,
+    }
+}
+
+/// The scroll axis source reported by `wl_pointer`.
+///
+/// This mirrors `wl_pointer::AxisSource` as plain values so this module needs
+/// no `wayland-client` dependency; the reducer translates the protocol enum
+/// into this type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AxisSource {
+    /// A physical scroll wheel with discrete detents.
+    Wheel,
+    /// A finger on a touchpad.
+    Finger,
+    /// Continuous, unbounded scrolling (for example a trackball or ring).
+    Continuous,
+    /// A tilting scroll wheel.
+    WheelTilt,
+}
+
+/// One `wl_pointer` frame's accumulated scroll, expressed as plain values.
+///
+/// `wl_pointer` batches axis events between `frame` events. A reducer sums each
+/// signal over a frame and then calls [`scroll_delta_from_axis_frame`] once per
+/// frame.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct AxisFrame {
+    /// The axis source for this frame, if the compositor reported one.
+    pub source: Option<AxisSource>,
+    /// Continuous axis value in logical pixels, `(x, y)`.
+    pub value: (f64, f64),
+    /// High-resolution wheel steps where `120` equals one detent, `(x, y)`
+    /// (`wl_pointer::axis_value120`, version 8+).
+    pub value120: (i32, i32),
+    /// Deprecated discrete detent count, `(x, y)` (`wl_pointer::axis_discrete`).
+    pub discrete: (i32, i32),
+}
+
+/// Convert an accumulated [`AxisFrame`] into a [`ScrollDelta`].
+///
+/// Returns `None` when the frame carries no scroll motion.
+///
+/// Wheel sources (and frames with no reported source) produce a
+/// [`ScrollDelta::LineDelta`] measured in wheel detents: high-resolution
+/// `value120` is preferred (divided by `120`), falling back to the deprecated
+/// discrete count, and finally to the continuous logical-pixel value as a
+/// [`ScrollDelta::PixelDelta`] when no detent signal is present.
+///
+/// Finger and continuous sources produce a [`ScrollDelta::PixelDelta`] in
+/// physical pixels (`value * scale_factor`).
+///
+/// Wayland's positive axis values mean down/right, matching [`ScrollDelta`]'s
+/// Y-down convention, so signs are preserved.
+pub fn scroll_delta_from_axis_frame(frame: AxisFrame, scale_factor: f64) -> Option<ScrollDelta> {
+    let scale_factor = positive_finite_or(scale_factor, 1.0);
+    let pixel_delta = |(x, y): (f64, f64)| {
+        ScrollDelta::PixelDelta(PhysicalPosition {
+            x: finite_or(x, 0.0) * scale_factor,
+            y: finite_or(y, 0.0) * scale_factor,
+        })
+    };
+    match frame.source {
+        Some(AxisSource::Finger | AxisSource::Continuous) => {
+            let (x, y) = frame.value;
+            (x != 0.0 || y != 0.0).then(|| pixel_delta((x, y)))
+        }
+        // `Wheel`, `WheelTilt`, or an unreported source: prefer discrete detents.
+        _ => {
+            let (x120, y120) = frame.value120;
+            let (xd, yd) = frame.discrete;
+            if x120 != 0 || y120 != 0 {
+                Some(ScrollDelta::LineDelta(
+                    x120 as f32 / 120.0,
+                    y120 as f32 / 120.0,
+                ))
+            } else if xd != 0 || yd != 0 {
+                Some(ScrollDelta::LineDelta(xd as f32, yd as f32))
+            } else {
+                let (x, y) = frame.value;
+                (x != 0.0 || y != 0.0).then(|| pixel_delta((x, y)))
+            }
+        }
+    }
+}
+
+/// Offset added to a platform-provided pointer identifier before constructing a
+/// [`PointerId`], so it can never collide with the reserved
+/// [`PointerId::PRIMARY`] (whose underlying value is `1`).
+///
+/// Offsetting platform id `0` by `2` makes the first platform-derived id `2`.
+pub const POINTER_ID_OFFSET: u64 = 2;
+
+/// Build a non-primary [`PointerId`] from a platform identifier.
+///
+/// Applies [`POINTER_ID_OFFSET`] so the result never aliases
+/// [`PointerId::PRIMARY`]. Returns `None` only on arithmetic overflow.
+pub fn pointer_id_from_platform_id(id: u64) -> Option<PointerId> {
+    id.checked_add(POINTER_ID_OFFSET).and_then(PointerId::new)
+}
+
+/// Build a [`PointerInfo`] for the primary pointer of the given [`PointerType`].
+pub fn primary_pointer_info(pointer_type: PointerType) -> PointerInfo {
+    PointerInfo {
+        pointer_id: Some(PointerId::PRIMARY),
+        persistent_device_id: None,
+        pointer_type,
+    }
+}
+
+/// Build a [`PointerInfo`] for a non-primary pointer of the given
+/// [`PointerType`] from a platform identifier.
+///
+/// The identifier is offset through [`pointer_id_from_platform_id`] to avoid
+/// colliding with [`PointerId::PRIMARY`].
+pub fn pointer_info_from_platform_id(pointer_type: PointerType, id: u64) -> PointerInfo {
+    PointerInfo {
+        pointer_id: pointer_id_from_platform_id(id),
+        persistent_device_id: None,
+        pointer_type,
+    }
+}
+
+/// Build a [`Modifiers`] set from individual modifier booleans.
+///
+/// Without an xkb keymap, `wl_keyboard` modifier state is an opaque bitmask, so
+/// the keyboard reducer tracks these booleans from physical modifier key
+/// presses and assembles them here.
+pub fn modifiers_from_bools(ctrl: bool, alt: bool, shift: bool, meta: bool) -> Modifiers {
+    let mut m = Modifiers::default();
+    if ctrl {
+        m.insert(Modifiers::CONTROL);
+    }
+    if alt {
+        m.insert(Modifiers::ALT);
+    }
+    if shift {
+        m.insert(Modifiers::SHIFT);
+    }
+    if meta {
+        m.insert(Modifiers::META);
+    }
+    m
+}
+
+#[inline]
+fn finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() { value } else { fallback }
+}
+
+#[inline]
+fn positive_finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() && value > 0.0 {
+        value
+    } else {
+        fallback
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evdev_buttons_map_to_expected_pointer_buttons() {
+        assert_eq!(
+            pointer_button_from_evdev(BTN_LEFT),
+            Some(PointerButton::Primary)
+        );
+        assert_eq!(
+            pointer_button_from_evdev(BTN_RIGHT),
+            Some(PointerButton::Secondary)
+        );
+        assert_eq!(
+            pointer_button_from_evdev(BTN_MIDDLE),
+            Some(PointerButton::Auxiliary)
+        );
+        assert_eq!(pointer_button_from_evdev(BTN_SIDE), Some(PointerButton::X1));
+        assert_eq!(
+            pointer_button_from_evdev(BTN_EXTRA),
+            Some(PointerButton::X2)
+        );
+        assert_eq!(
+            pointer_button_from_evdev(BTN_FORWARD),
+            Some(PointerButton::B7)
+        );
+        assert_eq!(pointer_button_from_evdev(BTN_BACK), Some(PointerButton::B8));
+        assert_eq!(pointer_button_from_evdev(BTN_TASK), Some(PointerButton::B9));
+    }
+
+    #[test]
+    fn evdev_unknown_button_is_none() {
+        // Just below `BTN_LEFT`, just above `BTN_TASK`, and `BTN_TOUCH`.
+        assert_eq!(pointer_button_from_evdev(0x10f), None);
+        assert_eq!(pointer_button_from_evdev(0x118), None);
+        assert_eq!(pointer_button_from_evdev(0x14a), None);
+    }
+
+    #[test]
+    fn logical_coordinates_scale_to_physical_pixels() {
+        assert_eq!(
+            physical_position_from_logical(10.0, 20.0, 2.0),
+            PhysicalPosition { x: 20.0, y: 40.0 }
+        );
+    }
+
+    #[test]
+    fn position_sanitizes_non_finite_inputs() {
+        // Non-finite scale falls back to 1.0; non-finite coordinate to 0.0.
+        assert_eq!(
+            physical_position_from_logical(f64::NAN, 5.0, f64::INFINITY),
+            PhysicalPosition { x: 0.0, y: 5.0 }
+        );
+    }
+
+    #[test]
+    fn wheel_frame_prefers_value120_over_discrete() {
+        let frame = AxisFrame {
+            source: Some(AxisSource::Wheel),
+            value: (0.0, 30.0),
+            value120: (0, 240),
+            discrete: (0, 2),
+        };
+        assert_eq!(
+            scroll_delta_from_axis_frame(frame, 2.0),
+            Some(ScrollDelta::LineDelta(0.0, 2.0))
+        );
+    }
+
+    #[test]
+    fn wheel_frame_falls_back_to_discrete() {
+        let frame = AxisFrame {
+            source: Some(AxisSource::Wheel),
+            discrete: (0, -1),
+            ..Default::default()
+        };
+        assert_eq!(
+            scroll_delta_from_axis_frame(frame, 1.0),
+            Some(ScrollDelta::LineDelta(0.0, -1.0))
+        );
+    }
+
+    #[test]
+    fn finger_frame_is_pixel_delta_scaled() {
+        let frame = AxisFrame {
+            source: Some(AxisSource::Finger),
+            value: (3.0, -4.0),
+            ..Default::default()
+        };
+        assert_eq!(
+            scroll_delta_from_axis_frame(frame, 2.0),
+            Some(ScrollDelta::PixelDelta(PhysicalPosition {
+                x: 6.0,
+                y: -8.0
+            }))
+        );
+    }
+
+    #[test]
+    fn empty_frame_is_none() {
+        assert_eq!(
+            scroll_delta_from_axis_frame(AxisFrame::default(), 1.0),
+            None
+        );
+    }
+
+    #[test]
+    fn sourceless_frame_with_only_value_is_pixel_delta() {
+        let frame = AxisFrame {
+            source: None,
+            value: (0.0, 12.0),
+            ..Default::default()
+        };
+        assert_eq!(
+            scroll_delta_from_axis_frame(frame, 1.0),
+            Some(ScrollDelta::PixelDelta(PhysicalPosition {
+                x: 0.0,
+                y: 12.0
+            }))
+        );
+    }
+
+    #[test]
+    fn platform_pointer_id_does_not_collide_with_primary() {
+        let id = pointer_id_from_platform_id(0).expect("offset id should be valid");
+        assert_eq!(id.get_inner().get(), POINTER_ID_OFFSET);
+        assert_ne!(id, PointerId::PRIMARY);
+    }
+
+    #[test]
+    fn primary_pointer_info_is_primary() {
+        let info = primary_pointer_info(PointerType::Mouse);
+        assert!(info.is_primary_pointer());
+        assert_eq!(info.pointer_type, PointerType::Mouse);
+    }
+
+    #[test]
+    fn platform_pointer_info_is_not_primary() {
+        let info = pointer_info_from_platform_id(PointerType::Touch, 0);
+        assert!(!info.is_primary_pointer());
+        assert_eq!(info.pointer_type, PointerType::Touch);
+        assert_eq!(info.pointer_id, PointerId::new(POINTER_ID_OFFSET));
+    }
+
+    #[test]
+    fn modifiers_from_bools_sets_expected_bits() {
+        let mods = modifiers_from_bools(true, false, true, false);
+        assert!(mods.ctrl());
+        assert!(!mods.alt());
+        assert!(mods.shift());
+        assert!(!mods.meta());
+    }
+}

--- a/ui-events-wayland/src/mapping.rs
+++ b/ui-events-wayland/src/mapping.rs
@@ -32,6 +32,10 @@ const BTN_EXTRA: u32 = 0x114;
 const BTN_FORWARD: u32 = 0x115;
 const BTN_BACK: u32 = 0x116;
 const BTN_TASK: u32 = 0x117;
+// evdev tablet-tool button codes from `linux/input-event-codes.h`.
+const BTN_STYLUS3: u32 = 0x149;
+const BTN_STYLUS: u32 = 0x14b;
+const BTN_STYLUS2: u32 = 0x14c;
 
 /// Map an evdev pointer button code to a [`PointerButton`].
 ///
@@ -63,6 +67,31 @@ pub fn pointer_button_from_evdev(code: u32) -> Option<PointerButton> {
         BTN_TASK => PointerButton::B9,
         _ => return None,
     })
+}
+
+/// Map an evdev tablet-tool button code to a [`PointerButton`].
+///
+/// `zwp_tablet_tool_v2` reports stylus barrel buttons by their
+/// `linux/input-event-codes.h` `BTN_STYLUS*` codes:
+///
+/// - `BTN_STYLUS` → [`PointerButton::Secondary`], which `ui-events` documents as
+///   the pen barrel button.
+/// - `BTN_STYLUS2` → [`PointerButton::B7`]
+/// - `BTN_STYLUS3` → [`PointerButton::B8`]
+///
+/// The second and third barrel buttons have no dedicated `ui-events` button, so
+/// they map into the generic `B7`/`B8` range rather than being conflated with
+/// the mouse side or auxiliary buttons, mirroring how
+/// [`pointer_button_from_evdev`] treats `BTN_FORWARD`/`BTN_BACK`/`BTN_TASK`. Any
+/// other code defers to [`pointer_button_from_evdev`], so a tablet tool used as a
+/// puck (the mouse and lens tool types) reuses the pointer-button table.
+pub fn pen_button_from_evdev(code: u32) -> Option<PointerButton> {
+    match code {
+        BTN_STYLUS => Some(PointerButton::Secondary),
+        BTN_STYLUS2 => Some(PointerButton::B7),
+        BTN_STYLUS3 => Some(PointerButton::B8),
+        other => pointer_button_from_evdev(other),
+    }
 }
 
 /// Convert Wayland surface-local logical coordinates to physical pixels.
@@ -336,6 +365,132 @@ pub fn rotation_radians_from_degrees(degrees: f64) -> f32 {
     finite_or(degrees, 0.0).to_radians() as f32
 }
 
+/// The physical type of a tablet tool, as reported by `zwp_tablet_tool_v2`.
+///
+/// This mirrors the protocol's `zwp_tablet_tool_v2::type` enum as plain values so
+/// this module needs no `wayland-protocols` dependency; the tablet reducer
+/// translates the protocol enum into this type.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ToolType {
+    /// A pen.
+    Pen,
+    /// An eraser, conventionally the opposite end of a pen.
+    Eraser,
+    /// A brush.
+    Brush,
+    /// A pencil.
+    Pencil,
+    /// An airbrush.
+    Airbrush,
+    /// A finger on a touch-capable tablet.
+    Finger,
+    /// A mouse-shaped tool bound to the tablet surface (a puck).
+    Mouse,
+    /// A mouse-shaped tool with a focusing lens.
+    Lens,
+}
+
+/// Map a tablet [`ToolType`] to the [`PointerType`] it reports as.
+///
+/// The pen-like drawing tools — pen, eraser, brush, pencil, and airbrush — report
+/// as [`PointerType::Pen`]; the puck-style mouse and lens tools as
+/// [`PointerType::Mouse`]; and the finger tool as [`PointerType::Touch`].
+pub fn pointer_type_from_tool(tool: ToolType) -> PointerType {
+    match tool {
+        ToolType::Pen
+        | ToolType::Eraser
+        | ToolType::Brush
+        | ToolType::Pencil
+        | ToolType::Airbrush => PointerType::Pen,
+        ToolType::Mouse | ToolType::Lens => PointerType::Mouse,
+        ToolType::Finger => PointerType::Touch,
+    }
+}
+
+/// The [`PointerButton`] a tablet tool's tip contact maps to.
+///
+/// A [`ToolType::Eraser`] tip maps to [`PointerButton::PenEraser`], matching the
+/// W3C Pointer Events eraser button; every other tool's tip maps to
+/// [`PointerButton::Primary`], the pen-contact / primary button.
+pub fn tip_button_from_tool(tool: ToolType) -> PointerButton {
+    match tool {
+        ToolType::Eraser => PointerButton::PenEraser,
+        _ => PointerButton::Primary,
+    }
+}
+
+/// The maximum value of a tablet tool's normalized axes (`pressure`, `distance`,
+/// and `slider`), per `zwp_tablet_tool_v2`.
+const TABLET_AXIS_NORMAL_MAX: f32 = 65535.0;
+
+/// Convert a `zwp_tablet_tool_v2::pressure` value into a normalized pressure.
+///
+/// Wayland reports tool pressure as an integer normalized to `[0, 65535]`. This
+/// divides by that maximum to produce the `[0, 1]` pressure
+/// [`PointerState`] expects, clamping to guard against out-of-range values.
+///
+/// [`PointerState`]: ui_events::pointer::PointerState
+pub fn pressure_from_normalized(value: u32) -> f32 {
+    (value as f32 / TABLET_AXIS_NORMAL_MAX).clamp(0.0, 1.0)
+}
+
+/// Convert a `zwp_tablet_tool_v2::slider` position into a tangential pressure.
+///
+/// Wayland reports the slider as a signed integer normalized to
+/// `[-65535, 65535]`. This divides by `65535` to produce the `[-1, 1]`
+/// tangential pressure [`PointerState`] expects, clamping to guard against
+/// out-of-range values. A tool slider is one of the controls
+/// [`PointerState::tangential_pressure`] is intended to carry.
+///
+/// [`PointerState`]: ui_events::pointer::PointerState
+/// [`PointerState::tangential_pressure`]: ui_events::pointer::PointerState::tangential_pressure
+pub fn tangential_pressure_from_slider(position: i32) -> f32 {
+    (position as f32 / TABLET_AXIS_NORMAL_MAX).clamp(-1.0, 1.0)
+}
+
+/// The tilt magnitude, in degrees, at which the pen is treated as parallel to the
+/// surface, kept just below `90°` so `tan` stays finite.
+const MAX_TILT_DEGREES: f32 = 89.9;
+
+/// Convert `zwp_tablet_tool_v2::tilt` angles into a [`PointerOrientation`].
+///
+/// Wayland reports the tilt as two angles in degrees: `tilt_x` is the deflection
+/// of the tool away from the surface normal toward the positive surface x-axis,
+/// and `tilt_y` toward the positive y-axis, each nominally in `[-90, 90]`. This
+/// matches the W3C Pointer Events `tiltX`/`tiltY` model, so the conversion mirrors
+/// the web backend: the pen axis is modelled as the vector `(tan(tilt_x),
+/// tan(tilt_y), 1)`, whose spherical altitude and azimuth become the
+/// orientation. A zero tilt yields the perpendicular default orientation.
+///
+/// The angles are clamped to just under `90°` so the tangents stay finite, and a
+/// non-finite angle is treated as `0`.
+pub fn pointer_orientation_from_tilt_degrees(
+    tilt_x_deg: f64,
+    tilt_y_deg: f64,
+) -> PointerOrientation {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "Wayland reports tilt as f64 degrees; ui-events stores orientation as f32"
+    )]
+    let (tilt_x, tilt_y) = (
+        (finite_or(tilt_x_deg, 0.0) as f32).clamp(-MAX_TILT_DEGREES, MAX_TILT_DEGREES),
+        (finite_or(tilt_y_deg, 0.0) as f32).clamp(-MAX_TILT_DEGREES, MAX_TILT_DEGREES),
+    );
+    let x = tilt_x.to_radians().tan();
+    let y = tilt_y.to_radians().tan();
+
+    // The pen axis is the normalized vector (x, y, 1); its z component is the
+    // sine of the altitude, and its projection onto the surface gives the azimuth.
+    let z = 1.0 / (x.mul_add(x, y * y) + 1.0).sqrt();
+    let altitude = z.asin();
+    let azimuth = if x == 0.0 && y == 0.0 {
+        core::f32::consts::FRAC_PI_2
+    } else {
+        y.atan2(x)
+    };
+    PointerOrientation { altitude, azimuth }
+}
+
 #[inline]
 fn finite_or(value: f64, fallback: f64) -> f64 {
     if value.is_finite() { value } else { fallback }
@@ -590,5 +745,101 @@ mod tests {
     #[test]
     fn rotation_non_finite_is_zero() {
         assert_eq!(rotation_radians_from_degrees(f64::INFINITY), 0.0);
+    }
+
+    #[test]
+    fn pen_buttons_map_barrel_and_defer_to_pointer_table() {
+        // The primary barrel button is the documented pen "Secondary" button.
+        assert_eq!(
+            pen_button_from_evdev(BTN_STYLUS),
+            Some(PointerButton::Secondary)
+        );
+        // Extra barrel buttons fall into the generic range.
+        assert_eq!(pen_button_from_evdev(BTN_STYLUS2), Some(PointerButton::B7));
+        assert_eq!(pen_button_from_evdev(BTN_STYLUS3), Some(PointerButton::B8));
+        // A puck tool's mouse buttons defer to the pointer-button table.
+        assert_eq!(
+            pen_button_from_evdev(BTN_LEFT),
+            Some(PointerButton::Primary)
+        );
+        // `BTN_TOUCH` (0x14a) sits between the stylus codes and maps to nothing.
+        assert_eq!(pen_button_from_evdev(0x14a), None);
+    }
+
+    #[test]
+    fn tool_types_map_to_expected_pointer_types() {
+        assert_eq!(pointer_type_from_tool(ToolType::Pen), PointerType::Pen);
+        assert_eq!(pointer_type_from_tool(ToolType::Eraser), PointerType::Pen);
+        assert_eq!(pointer_type_from_tool(ToolType::Airbrush), PointerType::Pen);
+        assert_eq!(pointer_type_from_tool(ToolType::Mouse), PointerType::Mouse);
+        assert_eq!(pointer_type_from_tool(ToolType::Lens), PointerType::Mouse);
+        assert_eq!(pointer_type_from_tool(ToolType::Finger), PointerType::Touch);
+    }
+
+    #[test]
+    fn eraser_tip_is_pen_eraser_others_are_primary() {
+        assert_eq!(
+            tip_button_from_tool(ToolType::Eraser),
+            PointerButton::PenEraser
+        );
+        assert_eq!(tip_button_from_tool(ToolType::Pen), PointerButton::Primary);
+        assert_eq!(
+            tip_button_from_tool(ToolType::Mouse),
+            PointerButton::Primary
+        );
+    }
+
+    #[test]
+    fn pressure_normalizes_and_clamps() {
+        assert_eq!(pressure_from_normalized(0), 0.0);
+        assert_eq!(pressure_from_normalized(65535), 1.0);
+        assert!((pressure_from_normalized(32768) - 0.5).abs() < 1e-4);
+        // Out-of-range values clamp into [0, 1].
+        assert_eq!(pressure_from_normalized(u32::MAX), 1.0);
+    }
+
+    #[test]
+    fn slider_normalizes_signed_and_clamps() {
+        assert_eq!(tangential_pressure_from_slider(0), 0.0);
+        assert_eq!(tangential_pressure_from_slider(65535), 1.0);
+        assert_eq!(tangential_pressure_from_slider(-65535), -1.0);
+        assert!((tangential_pressure_from_slider(32768) - 0.5).abs() < 1e-4);
+        // Out-of-range values clamp into [-1, 1].
+        assert_eq!(tangential_pressure_from_slider(i32::MIN), -1.0);
+    }
+
+    #[test]
+    fn zero_tilt_is_perpendicular() {
+        let orientation = pointer_orientation_from_tilt_degrees(0.0, 0.0);
+        assert!((orientation.altitude - core::f32::consts::FRAC_PI_2).abs() < 1e-5);
+        assert!((orientation.azimuth - core::f32::consts::FRAC_PI_2).abs() < 1e-5);
+    }
+
+    #[test]
+    fn tilt_axes_map_to_expected_azimuths() {
+        // Tilt toward +x points the azimuth along the x-axis (0).
+        let toward_x = pointer_orientation_from_tilt_degrees(30.0, 0.0);
+        assert!(toward_x.azimuth.abs() < 1e-5);
+        // Tilt toward +y points the azimuth along the y-axis (π/2).
+        let toward_y = pointer_orientation_from_tilt_degrees(0.0, 30.0);
+        assert!((toward_y.azimuth - core::f32::consts::FRAC_PI_2).abs() < 1e-5);
+        // More tilt lowers the altitude toward the surface.
+        assert!(toward_x.altitude < core::f32::consts::FRAC_PI_2);
+    }
+
+    #[test]
+    fn extreme_tilt_stays_finite() {
+        // Beyond the clamp the tangents would diverge; the result must stay finite.
+        let orientation = pointer_orientation_from_tilt_degrees(120.0, -120.0);
+        assert!(orientation.altitude.is_finite());
+        assert!(orientation.azimuth.is_finite());
+        assert!(orientation.altitude < 0.01);
+    }
+
+    #[test]
+    fn non_finite_tilt_is_perpendicular() {
+        let orientation = pointer_orientation_from_tilt_degrees(f64::NAN, f64::INFINITY);
+        assert!((orientation.altitude - core::f32::consts::FRAC_PI_2).abs() < 1e-5);
+        assert!((orientation.azimuth - core::f32::consts::FRAC_PI_2).abs() < 1e-5);
     }
 }

--- a/ui-events-wayland/src/mapping.rs
+++ b/ui-events-wayland/src/mapping.rs
@@ -23,6 +23,73 @@ use ui_events::pointer::{
     ContactGeometry, PointerButton, PointerId, PointerInfo, PointerOrientation, PointerType,
 };
 
+// `std` supplies these float methods; `no_std` builds route them through `libm`.
+// The tilt/orientation math works in `f32`, so the `libm` `*f` variants are used.
+// `to_radians`, `clamp`, and `abs` resolve in `core` and need no shim. See the
+// crate-level feature documentation.
+#[cfg(feature = "std")]
+fn tan(value: f32) -> f32 {
+    value.tan()
+}
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+fn tan(value: f32) -> f32 {
+    libm::tanf(value)
+}
+
+#[cfg(feature = "std")]
+fn asin(value: f32) -> f32 {
+    value.asin()
+}
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+fn asin(value: f32) -> f32 {
+    libm::asinf(value)
+}
+
+#[cfg(feature = "std")]
+fn atan2(y: f32, x: f32) -> f32 {
+    y.atan2(x)
+}
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+fn atan2(y: f32, x: f32) -> f32 {
+    libm::atan2f(y, x)
+}
+
+#[cfg(feature = "std")]
+fn mul_add(value: f32, a: f32, b: f32) -> f32 {
+    value.mul_add(a, b)
+}
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+fn mul_add(value: f32, a: f32, b: f32) -> f32 {
+    libm::fmaf(value, a, b)
+}
+
+#[cfg(feature = "std")]
+fn sqrt(value: f32) -> f32 {
+    value.sqrt()
+}
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+fn sqrt(value: f32) -> f32 {
+    libm::sqrtf(value)
+}
+
+/// Euclidean remainder of `value` by the positive `modulus`, in `[0, modulus)`.
+#[cfg(feature = "std")]
+fn rem_euclid(value: f32, modulus: f32) -> f32 {
+    value.rem_euclid(modulus)
+}
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+fn rem_euclid(value: f32, modulus: f32) -> f32 {
+    let remainder = libm::fmodf(value, modulus);
+    if remainder < 0.0 {
+        remainder + modulus.abs()
+    } else {
+        remainder
+    }
+}
+
+#[cfg(all(not(feature = "std"), not(feature = "libm")))]
+compile_error!("ui-events-wayland requires either the `std` or `libm` feature");
+
 // evdev pointer button codes from `linux/input-event-codes.h`.
 const BTN_LEFT: u32 = 0x110;
 const BTN_RIGHT: u32 = 0x111;
@@ -806,8 +873,10 @@ pub fn touch_orientation_from_degrees(orientation_deg: f64) -> PointerOrientatio
         clippy::cast_possible_truncation,
         reason = "Wayland reports orientation as f64 degrees; ui-events stores azimuth as f32"
     )]
-    let azimuth = (core::f32::consts::FRAC_PI_2 + (orientation_deg as f32).to_radians())
-        .rem_euclid(core::f32::consts::TAU);
+    let azimuth = rem_euclid(
+        core::f32::consts::FRAC_PI_2 + (orientation_deg as f32).to_radians(),
+        core::f32::consts::TAU,
+    );
     PointerOrientation {
         altitude: core::f32::consts::FRAC_PI_2,
         azimuth,
@@ -972,17 +1041,17 @@ pub fn pointer_orientation_from_tilt_degrees(
         (finite_or(tilt_x_deg, 0.0) as f32).clamp(-MAX_TILT_DEGREES, MAX_TILT_DEGREES),
         (finite_or(tilt_y_deg, 0.0) as f32).clamp(-MAX_TILT_DEGREES, MAX_TILT_DEGREES),
     );
-    let x = tilt_x.to_radians().tan();
-    let y = tilt_y.to_radians().tan();
+    let x = tan(tilt_x.to_radians());
+    let y = tan(tilt_y.to_radians());
 
     // The pen axis is the normalized vector (x, y, 1); its z component is the
     // sine of the altitude, and its projection onto the surface gives the azimuth.
-    let z = 1.0 / (x.mul_add(x, y * y) + 1.0).sqrt();
-    let altitude = z.asin();
+    let z = 1.0 / sqrt(mul_add(x, x, y * y) + 1.0);
+    let altitude = asin(z);
     let azimuth = if x == 0.0 && y == 0.0 {
         core::f32::consts::FRAC_PI_2
     } else {
-        y.atan2(x)
+        atan2(y, x)
     };
     PointerOrientation { altitude, azimuth }
 }

--- a/ui-events-wayland/src/mapping.rs
+++ b/ui-events-wayland/src/mapping.rs
@@ -18,7 +18,7 @@
 
 use dpi::PhysicalPosition;
 use ui_events::ScrollDelta;
-use ui_events::keyboard::Modifiers;
+use ui_events::keyboard::{Code, Modifiers};
 use ui_events::pointer::{
     ContactGeometry, PointerButton, PointerId, PointerInfo, PointerOrientation, PointerType,
 };
@@ -253,6 +253,172 @@ pub fn modifiers_from_bools(ctrl: bool, alt: bool, shift: bool, meta: bool) -> M
         m.insert(Modifiers::META);
     }
     m
+}
+
+/// Map an evdev keyboard scancode to its physical [`Code`].
+///
+/// `wl_keyboard` reports each key by the Linux kernel's evdev scancode (the
+/// `KEY_*` values from `linux/input-event-codes.h`); the same raw scancodes
+/// appear in the `keys` array of a focus `enter` event. This maps that physical
+/// position to the corresponding W3C UI Events [`Code`] for a standard PC
+/// keyboard, independent of the active layout, mirroring the table the `winit`
+/// adapter uses for X11 and Wayland. The Linux `KEY_LEFTMETA`/`KEY_RIGHTMETA`
+/// keys map to [`Code::MetaLeft`]/[`Code::MetaRight`], the W3C names for the
+/// operating-system ("super") keys.
+///
+/// To resolve the same scancode against an xkb keymap, add `8` to obtain the xkb
+/// keycode; that path is handled under the `xkb` feature.
+///
+/// Scancodes with no standard physical key — including the rarer multimedia,
+/// browser, and power keys — return [`Code::Unidentified`].
+pub fn code_from_evdev_scancode(scancode: u32) -> Code {
+    match scancode {
+        // Main typing area: the alphanumeric block, punctuation, and the keys
+        // that border it.
+        1 => Code::Escape,
+        2 => Code::Digit1,
+        3 => Code::Digit2,
+        4 => Code::Digit3,
+        5 => Code::Digit4,
+        6 => Code::Digit5,
+        7 => Code::Digit6,
+        8 => Code::Digit7,
+        9 => Code::Digit8,
+        10 => Code::Digit9,
+        11 => Code::Digit0,
+        12 => Code::Minus,
+        13 => Code::Equal,
+        14 => Code::Backspace,
+        15 => Code::Tab,
+        16 => Code::KeyQ,
+        17 => Code::KeyW,
+        18 => Code::KeyE,
+        19 => Code::KeyR,
+        20 => Code::KeyT,
+        21 => Code::KeyY,
+        22 => Code::KeyU,
+        23 => Code::KeyI,
+        24 => Code::KeyO,
+        25 => Code::KeyP,
+        26 => Code::BracketLeft,
+        27 => Code::BracketRight,
+        28 => Code::Enter,
+        29 => Code::ControlLeft,
+        30 => Code::KeyA,
+        31 => Code::KeyS,
+        32 => Code::KeyD,
+        33 => Code::KeyF,
+        34 => Code::KeyG,
+        35 => Code::KeyH,
+        36 => Code::KeyJ,
+        37 => Code::KeyK,
+        38 => Code::KeyL,
+        39 => Code::Semicolon,
+        40 => Code::Quote,
+        41 => Code::Backquote,
+        42 => Code::ShiftLeft,
+        43 => Code::Backslash,
+        44 => Code::KeyZ,
+        45 => Code::KeyX,
+        46 => Code::KeyC,
+        47 => Code::KeyV,
+        48 => Code::KeyB,
+        49 => Code::KeyN,
+        50 => Code::KeyM,
+        51 => Code::Comma,
+        52 => Code::Period,
+        53 => Code::Slash,
+        54 => Code::ShiftRight,
+        55 => Code::NumpadMultiply,
+        56 => Code::AltLeft,
+        57 => Code::Space,
+        58 => Code::CapsLock,
+        // Function keys F1 through F10.
+        59 => Code::F1,
+        60 => Code::F2,
+        61 => Code::F3,
+        62 => Code::F4,
+        63 => Code::F5,
+        64 => Code::F6,
+        65 => Code::F7,
+        66 => Code::F8,
+        67 => Code::F9,
+        68 => Code::F10,
+        // Locks and the numeric keypad.
+        69 => Code::NumLock,
+        70 => Code::ScrollLock,
+        71 => Code::Numpad7,
+        72 => Code::Numpad8,
+        73 => Code::Numpad9,
+        74 => Code::NumpadSubtract,
+        75 => Code::Numpad4,
+        76 => Code::Numpad5,
+        77 => Code::Numpad6,
+        78 => Code::NumpadAdd,
+        79 => Code::Numpad1,
+        80 => Code::Numpad2,
+        81 => Code::Numpad3,
+        82 => Code::Numpad0,
+        83 => Code::NumpadDecimal,
+        // International keys, the second function-key pair, and the editing and
+        // navigation cluster.
+        85 => Code::Lang5,
+        86 => Code::IntlBackslash,
+        87 => Code::F11,
+        88 => Code::F12,
+        89 => Code::IntlRo,
+        90 => Code::Lang3,
+        91 => Code::Lang4,
+        92 => Code::Convert,
+        93 => Code::KanaMode,
+        94 => Code::NonConvert,
+        96 => Code::NumpadEnter,
+        97 => Code::ControlRight,
+        98 => Code::NumpadDivide,
+        99 => Code::PrintScreen,
+        100 => Code::AltRight,
+        102 => Code::Home,
+        103 => Code::ArrowUp,
+        104 => Code::PageUp,
+        105 => Code::ArrowLeft,
+        106 => Code::ArrowRight,
+        107 => Code::End,
+        108 => Code::ArrowDown,
+        109 => Code::PageDown,
+        110 => Code::Insert,
+        111 => Code::Delete,
+        113 => Code::AudioVolumeMute,
+        114 => Code::AudioVolumeDown,
+        115 => Code::AudioVolumeUp,
+        117 => Code::NumpadEqual,
+        119 => Code::Pause,
+        121 => Code::NumpadComma,
+        122 => Code::Lang1,
+        123 => Code::Lang2,
+        124 => Code::IntlYen,
+        // The operating-system keys are W3C `Meta`, and the application/menu key.
+        125 => Code::MetaLeft,
+        126 => Code::MetaRight,
+        127 => Code::ContextMenu,
+        // A few common media keys and the high function-key range.
+        163 => Code::MediaTrackNext,
+        164 => Code::MediaPlayPause,
+        165 => Code::MediaTrackPrevious,
+        166 => Code::MediaStop,
+        183 => Code::F13,
+        184 => Code::F14,
+        185 => Code::F15,
+        186 => Code::F16,
+        187 => Code::F17,
+        188 => Code::F18,
+        189 => Code::F19,
+        190 => Code::F20,
+        191 => Code::F21,
+        192 => Code::F22,
+        193 => Code::F23,
+        194 => Code::F24,
+        _ => Code::Unidentified,
+    }
 }
 
 /// Build a [`PointerInfo`] for a touch contact, reserving [`PointerId::PRIMARY`]
@@ -657,6 +823,50 @@ mod tests {
         assert!(!mods.alt());
         assert!(mods.shift());
         assert!(!mods.meta());
+    }
+
+    #[test]
+    fn evdev_scancodes_map_to_expected_physical_codes() {
+        // Representative keys; the `KEY_*` values are from
+        // `linux/input-event-codes.h`.
+        assert_eq!(code_from_evdev_scancode(30), Code::KeyA);
+        assert_eq!(code_from_evdev_scancode(1), Code::Escape);
+        assert_eq!(code_from_evdev_scancode(28), Code::Enter);
+        assert_eq!(code_from_evdev_scancode(57), Code::Space);
+        // The top-row digits are distinct from the numeric keypad.
+        assert_eq!(code_from_evdev_scancode(2), Code::Digit1);
+        assert_eq!(code_from_evdev_scancode(11), Code::Digit0);
+        assert_eq!(code_from_evdev_scancode(82), Code::Numpad0);
+        assert_eq!(code_from_evdev_scancode(96), Code::NumpadEnter);
+        // Function keys span a low and a high range.
+        assert_eq!(code_from_evdev_scancode(59), Code::F1);
+        assert_eq!(code_from_evdev_scancode(88), Code::F12);
+        assert_eq!(code_from_evdev_scancode(183), Code::F13);
+        assert_eq!(code_from_evdev_scancode(194), Code::F24);
+    }
+
+    #[test]
+    fn evdev_modifier_scancodes_map_to_sided_codes() {
+        assert_eq!(code_from_evdev_scancode(29), Code::ControlLeft);
+        assert_eq!(code_from_evdev_scancode(97), Code::ControlRight);
+        assert_eq!(code_from_evdev_scancode(42), Code::ShiftLeft);
+        assert_eq!(code_from_evdev_scancode(54), Code::ShiftRight);
+        assert_eq!(code_from_evdev_scancode(56), Code::AltLeft);
+        assert_eq!(code_from_evdev_scancode(100), Code::AltRight);
+        // The Linux meta/super keys are the W3C Meta keys.
+        assert_eq!(code_from_evdev_scancode(125), Code::MetaLeft);
+        assert_eq!(code_from_evdev_scancode(126), Code::MetaRight);
+    }
+
+    #[test]
+    fn unmapped_evdev_scancodes_are_unidentified() {
+        // `0` is reserved, `84` is a gap in the table, `116` (`KEY_POWER`) and
+        // the rarer multimedia keys are intentionally unmapped, and very large
+        // values have no key.
+        assert_eq!(code_from_evdev_scancode(0), Code::Unidentified);
+        assert_eq!(code_from_evdev_scancode(84), Code::Unidentified);
+        assert_eq!(code_from_evdev_scancode(116), Code::Unidentified);
+        assert_eq!(code_from_evdev_scancode(u32::MAX), Code::Unidentified);
     }
 
     #[test]

--- a/ui-events-wayland/src/mapping.rs
+++ b/ui-events-wayland/src/mapping.rs
@@ -289,6 +289,53 @@ pub fn touch_orientation_from_degrees(orientation_deg: f64) -> PointerOrientatio
     }
 }
 
+/// Convert a `zwp_pointer_gesture_pinch_v1` absolute pinch scale into the
+/// signed, per-update scale fraction carried by [`PointerGesture::Pinch`].
+///
+/// Wayland reports the pinch `scale` as an absolute ratio relative to the
+/// gesture's `begin` event, which is implicitly `1.0` — a `scale` of `2.0` means
+/// the fingers are twice as far apart as they were at `begin`.
+/// [`PointerGesture::Pinch`] instead carries the signed fractional change for a
+/// single update, where `0.1` means "grow by 10%" and the update rule is
+/// `new_scale = current_scale * (1.0 + delta)`. Given the absolute scale from
+/// the previous update (or `1.0` at the start of the gesture) as `previous` and
+/// the absolute scale from the current update as `current`, this returns
+/// `current / previous - 1.0`.
+///
+/// A non-finite or non-positive `previous` falls back to `1.0`, and a
+/// non-finite or non-positive `current` is treated as unchanged from `previous`,
+/// yielding `0.0`.
+///
+/// [`PointerGesture::Pinch`]: ui_events::pointer::PointerGesture::Pinch
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Wayland reports scale as f64; ui-events stores the pinch fraction as f32"
+)]
+pub fn pinch_scale_fraction(previous: f64, current: f64) -> f32 {
+    let previous = positive_finite_or(previous, 1.0);
+    let current = positive_finite_or(current, previous);
+    (current / previous - 1.0) as f32
+}
+
+/// Convert a `zwp_pointer_gesture_pinch_v1` rotation into the clockwise radians
+/// carried by [`PointerGesture::Rotate`].
+///
+/// Wayland reports the pinch `rotation` as an angle in degrees, measured
+/// clockwise, accumulated since the previous `begin` or `update` event — already
+/// a per-update delta. [`PointerGesture::Rotate`] is likewise a clockwise,
+/// per-update delta, but measured in radians, so this is a plain
+/// degrees-to-radians conversion that preserves the sign. A non-finite angle
+/// yields `0.0`.
+///
+/// [`PointerGesture::Rotate`]: ui_events::pointer::PointerGesture::Rotate
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "Wayland reports rotation as f64 degrees; ui-events stores the angle as f32"
+)]
+pub fn rotation_radians_from_degrees(degrees: f64) -> f32 {
+    finite_or(degrees, 0.0).to_radians() as f32
+}
+
 #[inline]
 fn finite_or(value: f64, fallback: f64) -> f64 {
     if value.is_finite() { value } else { fallback }
@@ -506,5 +553,42 @@ mod tests {
             touch_orientation_from_degrees(f64::INFINITY),
             PointerOrientation::default()
         );
+    }
+
+    #[test]
+    fn pinch_growth_is_a_positive_fraction() {
+        // Growing from the 1.0 begin baseline to 1.1 is a 10% increase.
+        assert!((pinch_scale_fraction(1.0, 1.1) - 0.1).abs() < 1e-6);
+    }
+
+    #[test]
+    fn pinch_shrink_is_a_negative_fraction() {
+        assert!((pinch_scale_fraction(1.0, 0.5) + 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn pinch_fraction_is_relative_to_the_previous_scale() {
+        // Two updates each growing the absolute scale by 10% each report ~10%,
+        // because the protocol's scale is absolute, not per-update.
+        assert!((pinch_scale_fraction(1.1, 1.21) - 0.1).abs() < 1e-5);
+    }
+
+    #[test]
+    fn pinch_fraction_sanitizes_degenerate_scales() {
+        // Non-positive previous falls back to 1.0; non-finite current is treated
+        // as no change.
+        assert_eq!(pinch_scale_fraction(0.0, 1.0), 0.0);
+        assert_eq!(pinch_scale_fraction(1.0, f64::NAN), 0.0);
+    }
+
+    #[test]
+    fn rotation_converts_degrees_to_clockwise_radians() {
+        assert!((rotation_radians_from_degrees(90.0) - core::f32::consts::FRAC_PI_2).abs() < 1e-6);
+        assert!((rotation_radians_from_degrees(-45.0) + core::f32::consts::FRAC_PI_4).abs() < 1e-6);
+    }
+
+    #[test]
+    fn rotation_non_finite_is_zero() {
+        assert_eq!(rotation_radians_from_degrees(f64::INFINITY), 0.0);
     }
 }

--- a/ui-events-wayland/src/pointer.rs
+++ b/ui-events-wayland/src/pointer.rs
@@ -317,14 +317,16 @@ struct TapState {
     y: f64,
 }
 
+/// Tracks multi-click and multi-tap `count` by watching the [`PointerEvent`]s a
+/// reducer emits. Shared by the pointer and touch reducers.
 #[derive(Debug, Default)]
-struct TapCounter {
+pub(crate) struct TapCounter {
     taps: Vec<TapState>,
 }
 
 impl TapCounter {
     /// Enhance a [`PointerEvent`] with a `count`.
-    fn attach_count(&mut self, scale_factor: f64, e: PointerEvent) -> PointerEvent {
+    pub(crate) fn attach_count(&mut self, scale_factor: f64, e: PointerEvent) -> PointerEvent {
         match e {
             PointerEvent::Down(mut event) => {
                 let pointer_id = event.pointer.pointer_id;

--- a/ui-events-wayland/src/pointer.rs
+++ b/ui-events-wayland/src/pointer.rs
@@ -22,6 +22,8 @@
 //!
 //! [`PointerState`]: ui_events::pointer::PointerState
 
+use alloc::{vec, vec::Vec};
+
 use ui_events::pointer::{
     PointerButtonEvent, PointerEvent, PointerId, PointerInfo, PointerScrollEvent, PointerState,
     PointerType, PointerUpdate,

--- a/ui-events-wayland/src/pointer.rs
+++ b/ui-events-wayland/src/pointer.rs
@@ -1,0 +1,668 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Reduces `wl_pointer` event streams into [`PointerEvent`]s.
+//!
+//! [`PointerEventReducer`] mirrors the stateful-reducer pattern of the other
+//! adapters: feed it each `wl_pointer` event for a seat's pointer together with
+//! a caller-provided monotonic timestamp, and it tracks the primary pointer's
+//! [`PointerState`] and emits [`PointerEvent`]s.
+//!
+//! Wayland groups the events that logically belong together — for example the
+//! horizontal and vertical axes of one diagonal scroll — between `frame`
+//! events. The reducer accumulates scroll axes across a frame and emits a
+//! single [`PointerEvent::Scroll`] when the `frame` arrives. Every other event
+//! is translated as it arrives, so most calls return zero or one event; the
+//! returned [`Vec`] exists so a `frame` can flush an accumulated scroll.
+//!
+//! Surface-local coordinates are converted to physical pixels through
+//! [`mapping::physical_position_from_logical`], and the serial of the most
+//! recent `enter` event is exposed through [`PointerEventReducer::enter_serial`]
+//! for issuing `wl_pointer::set_cursor`.
+//!
+//! [`PointerState`]: ui_events::pointer::PointerState
+
+use ui_events::pointer::{
+    PointerButtonEvent, PointerEvent, PointerId, PointerInfo, PointerScrollEvent, PointerState,
+    PointerType, PointerUpdate,
+};
+use wayland_client::WEnum;
+use wayland_client::protocol::wl_pointer::{self, Axis, ButtonState, Event};
+
+use crate::mapping::{self, AxisFrame};
+
+/// The [`PointerInfo`] describing a seat's primary mouse pointer.
+fn primary_mouse() -> PointerInfo {
+    mapping::primary_pointer_info(PointerType::Mouse)
+}
+
+/// Reduces a `wl_pointer` event stream into [`PointerEvent`]s.
+///
+/// Keep one reducer per seat pointer and call [`reduce`] with each `wl_pointer`
+/// event. See the [module documentation] for the batching and timing model.
+///
+/// [`reduce`]: PointerEventReducer::reduce
+/// [module documentation]: self
+#[derive(Debug)]
+pub struct PointerEventReducer {
+    /// State of the primary pointer.
+    primary_state: PointerState,
+    /// Click counter.
+    counter: TapCounter,
+    /// Last caller-provided timestamp, for the monotonicity debug assertion.
+    last_seen_time: Option<u64>,
+    /// Serial of the most recent `enter` event, cleared on `leave`.
+    enter_serial: Option<u32>,
+    /// Scroll accumulated since the last `frame` event.
+    axis_frame: AxisFrame,
+    /// Whether axis events are grouped by `frame` (`wl_pointer` version 5+).
+    frame_batched: bool,
+}
+
+impl Default for PointerEventReducer {
+    fn default() -> Self {
+        Self {
+            primary_state: PointerState::default(),
+            counter: TapCounter::default(),
+            last_seen_time: None,
+            enter_serial: None,
+            axis_frame: AxisFrame::default(),
+            frame_batched: true,
+        }
+    }
+}
+
+impl PointerEventReducer {
+    /// Create a reducer for a `wl_pointer` bound at the given protocol `version`.
+    ///
+    /// Version 5 introduced the `frame` event that groups the axis events of one
+    /// logical scroll. For version 5 and later (the [`Default`]), the reducer
+    /// accumulates scroll axes and emits a single [`PointerEvent::Scroll`] on
+    /// `frame`. Earlier versions have no `frame` event, so each axis event is
+    /// emitted as its own scroll.
+    pub fn for_version(version: u32) -> Self {
+        Self {
+            frame_batched: version >= 5,
+            ..Self::default()
+        }
+    }
+
+    /// The serial of the most recent `enter` event, while the pointer is over a
+    /// surface.
+    ///
+    /// `wl_pointer::set_cursor` requires the serial of the latest `enter` event;
+    /// consumers read it from here. It is cleared on `leave`.
+    pub fn enter_serial(&self) -> Option<u32> {
+        self.enter_serial
+    }
+
+    /// Reduce a single `wl_pointer` [`Event`] into zero or more [`PointerEvent`]s.
+    ///
+    /// `time` is a monotonic nanosecond timestamp in the consumer's clock
+    /// domain. It is stamped into every [`PointerState`] this call produces,
+    /// including the `frame`-driven scroll, so input shares one timeline with
+    /// frame sampling, timers, and diagnostics; Wayland's own 32-bit millisecond
+    /// event timestamps are deliberately not used as the clock. `scale_factor`
+    /// converts surface-local logical coordinates to physical pixels.
+    ///
+    /// `time` must be monotonic across calls; a regression trips a
+    /// `debug_assert!`, since click detection measures durations in nanoseconds.
+    pub fn reduce(&mut self, scale_factor: f64, event: &Event, time: u64) -> Vec<PointerEvent> {
+        self.check_time_monotonic(time);
+        self.primary_state.time = time;
+        self.primary_state.scale_factor = scale_factor;
+
+        match event {
+            Event::Enter {
+                serial,
+                surface_x,
+                surface_y,
+                ..
+            } => vec![self.enter(*serial, *surface_x, *surface_y)],
+            Event::Leave { .. } => vec![self.leave()],
+            Event::Motion {
+                surface_x,
+                surface_y,
+                ..
+            } => {
+                self.set_position(*surface_x, *surface_y);
+                vec![self.counter.attach_count(
+                    scale_factor,
+                    PointerEvent::Move(PointerUpdate {
+                        pointer: primary_mouse(),
+                        current: self.primary_state.clone(),
+                        coalesced: Vec::new(),
+                        predicted: Vec::new(),
+                    }),
+                )]
+            }
+            Event::Button { button, state, .. } => self.button(*button, *state, scale_factor),
+            Event::Axis { axis, value, .. } => {
+                self.accumulate_axis_value(*axis, *value);
+                // Versions before 5 have no `frame`, so each axis stands alone.
+                if self.frame_batched {
+                    Vec::new()
+                } else {
+                    self.flush_scroll(scale_factor)
+                }
+            }
+            Event::AxisSource { axis_source } => {
+                if let Some(source) = map_axis_source(*axis_source) {
+                    self.axis_frame.source = Some(source);
+                }
+                Vec::new()
+            }
+            Event::AxisValue120 { axis, value120 } => {
+                self.accumulate_axis_value120(*axis, *value120);
+                Vec::new()
+            }
+            Event::AxisDiscrete { axis, discrete } => {
+                self.accumulate_axis_discrete(*axis, *discrete);
+                Vec::new()
+            }
+            Event::Frame => self.flush_scroll(scale_factor),
+            // `axis_stop` (kinetic-scroll end) and `axis_relative_direction`
+            // (a natural-scroll hint) have no ui-events representation.
+            Event::AxisStop { .. } | Event::AxisRelativeDirection { .. } => Vec::new(),
+            // `wl_pointer::Event` is `#[non_exhaustive]`; ignore future additions.
+            _ => Vec::new(),
+        }
+    }
+
+    /// Update the tracked position from surface-local logical coordinates.
+    fn set_position(&mut self, surface_x: f64, surface_y: f64) {
+        self.primary_state.position = mapping::physical_position_from_logical(
+            surface_x,
+            surface_y,
+            self.primary_state.scale_factor,
+        );
+    }
+
+    /// Handle an `enter` event: record the serial and update the position.
+    ///
+    /// This takes the surface-local coordinates rather than the `wl_surface`, so
+    /// the surface-independent logic stays unit-testable without a live
+    /// connection (a `wl_surface` cannot be constructed without one).
+    fn enter(&mut self, serial: u32, surface_x: f64, surface_y: f64) -> PointerEvent {
+        self.enter_serial = Some(serial);
+        self.set_position(surface_x, surface_y);
+        PointerEvent::Enter(primary_mouse())
+    }
+
+    /// Handle a `leave` event: clear the enter serial.
+    fn leave(&mut self) -> PointerEvent {
+        self.enter_serial = None;
+        PointerEvent::Leave(primary_mouse())
+    }
+
+    /// Handle a `button` event: update the button set and emit a down or up.
+    fn button(
+        &mut self,
+        code: u32,
+        state: WEnum<ButtonState>,
+        scale_factor: f64,
+    ) -> Vec<PointerEvent> {
+        let button = mapping::pointer_button_from_evdev(code);
+        match state {
+            WEnum::Value(ButtonState::Pressed) => {
+                if let Some(button) = button {
+                    self.primary_state.buttons.insert(button);
+                }
+                vec![self.counter.attach_count(
+                    scale_factor,
+                    PointerEvent::Down(PointerButtonEvent {
+                        button,
+                        pointer: primary_mouse(),
+                        state: self.primary_state.clone(),
+                    }),
+                )]
+            }
+            WEnum::Value(ButtonState::Released) => {
+                if let Some(button) = button {
+                    self.primary_state.buttons.remove(button);
+                }
+                vec![self.counter.attach_count(
+                    scale_factor,
+                    PointerEvent::Up(PointerButtonEvent {
+                        button,
+                        pointer: primary_mouse(),
+                        state: self.primary_state.clone(),
+                    }),
+                )]
+            }
+            // Unknown button state.
+            _ => Vec::new(),
+        }
+    }
+
+    /// Add a continuous axis value (logical pixels) to the current frame.
+    fn accumulate_axis_value(&mut self, axis: WEnum<Axis>, value: f64) {
+        match axis {
+            WEnum::Value(Axis::VerticalScroll) => self.axis_frame.value.1 += value,
+            WEnum::Value(Axis::HorizontalScroll) => self.axis_frame.value.0 += value,
+            _ => {}
+        }
+    }
+
+    /// Add a high-resolution (`value120`) axis step to the current frame.
+    fn accumulate_axis_value120(&mut self, axis: WEnum<Axis>, value120: i32) {
+        match axis {
+            WEnum::Value(Axis::VerticalScroll) => self.axis_frame.value120.1 += value120,
+            WEnum::Value(Axis::HorizontalScroll) => self.axis_frame.value120.0 += value120,
+            _ => {}
+        }
+    }
+
+    /// Add a deprecated discrete-detent axis step to the current frame.
+    fn accumulate_axis_discrete(&mut self, axis: WEnum<Axis>, discrete: i32) {
+        match axis {
+            WEnum::Value(Axis::VerticalScroll) => self.axis_frame.discrete.1 += discrete,
+            WEnum::Value(Axis::HorizontalScroll) => self.axis_frame.discrete.0 += discrete,
+            _ => {}
+        }
+    }
+
+    /// Emit the scroll accumulated since the last flush, if any, and reset the
+    /// frame.
+    fn flush_scroll(&mut self, scale_factor: f64) -> Vec<PointerEvent> {
+        let frame = core::mem::take(&mut self.axis_frame);
+        match mapping::scroll_delta_from_axis_frame(frame, scale_factor) {
+            Some(delta) => vec![PointerEvent::Scroll(PointerScrollEvent {
+                pointer: primary_mouse(),
+                delta,
+                state: self.primary_state.clone(),
+            })],
+            None => Vec::new(),
+        }
+    }
+
+    /// Debug-assert that caller timestamps do not regress.
+    fn check_time_monotonic(&mut self, time: u64) {
+        if let Some(previous) = self.last_seen_time {
+            debug_assert!(
+                time >= previous,
+                "PointerEventReducer::reduce timestamps must be monotonic nanoseconds"
+            );
+        }
+        self.last_seen_time = Some(time);
+    }
+}
+
+/// Translate a `wl_pointer` axis source into the neutral [`mapping::AxisSource`].
+fn map_axis_source(source: WEnum<wl_pointer::AxisSource>) -> Option<mapping::AxisSource> {
+    match source {
+        WEnum::Value(wl_pointer::AxisSource::Wheel) => Some(mapping::AxisSource::Wheel),
+        WEnum::Value(wl_pointer::AxisSource::Finger) => Some(mapping::AxisSource::Finger),
+        WEnum::Value(wl_pointer::AxisSource::Continuous) => Some(mapping::AxisSource::Continuous),
+        WEnum::Value(wl_pointer::AxisSource::WheelTilt) => Some(mapping::AxisSource::WheelTilt),
+        _ => None,
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TapState {
+    /// Pointer ID this tap is tracked against.
+    pointer_id: Option<PointerId>,
+    /// Nanosecond timestamp when the tap went down.
+    down_time: u64,
+    /// Nanosecond timestamp when the tap went up.
+    ///
+    /// Resets to `down_time` when the tap goes down.
+    up_time: u64,
+    /// The local tap count as of the last down phase.
+    count: u8,
+    /// x coordinate of the anchor point.
+    x: f64,
+    /// y coordinate of the anchor point.
+    y: f64,
+}
+
+#[derive(Debug, Default)]
+struct TapCounter {
+    taps: Vec<TapState>,
+}
+
+impl TapCounter {
+    /// Enhance a [`PointerEvent`] with a `count`.
+    fn attach_count(&mut self, scale_factor: f64, e: PointerEvent) -> PointerEvent {
+        match e {
+            PointerEvent::Down(mut event) => {
+                let pointer_id = event.pointer.pointer_id;
+                let position = event.state.position;
+                let time = event.state.time;
+
+                let slop = match event.pointer.pointer_type {
+                    // This is on the low side of double tap slop, validated
+                    // experimentally to work on a few touchscreen laptops.
+                    PointerType::Touch => 12.0,
+                    PointerType::Pen => 6.0,
+                    // This is slightly more forgiving than the default on Windows for mice.
+                    // In order to make the slop calculation more similar between devices,
+                    // this uses a slightly different method than Windows, which tests if the
+                    // tap is in a box, rather than in a circle, centered on the anchor point.
+                    _ => 2.0,
+                } * core::f64::consts::SQRT_2
+                    * scale_factor;
+
+                if let Some(tap) =
+                    self.taps.iter_mut().find(|TapState { x, y, up_time, .. }| {
+                        let dx = (x - position.x).abs();
+                        let dy = (y - position.y).abs();
+                        (dx * dx + dy * dy).sqrt() < slop && (up_time + 500_000_000) > time
+                    })
+                {
+                    let count = tap.count + 1;
+                    event.state.count = count;
+                    tap.count = count;
+                    tap.pointer_id = pointer_id;
+                    tap.down_time = time;
+                    tap.up_time = time;
+                    tap.x = position.x;
+                    tap.y = position.y;
+                } else {
+                    let s = TapState {
+                        pointer_id,
+                        down_time: time,
+                        up_time: time,
+                        count: 1,
+                        x: position.x,
+                        y: position.y,
+                    };
+                    if let Some(t) = self
+                        .taps
+                        .iter_mut()
+                        .find(|state| state.pointer_id == pointer_id)
+                    {
+                        *t = s;
+                    } else {
+                        self.taps.push(s);
+                    }
+                    event.state.count = 1;
+                };
+                self.clear_expired(time);
+                PointerEvent::Down(event)
+            }
+            PointerEvent::Up(mut event) => {
+                let p_id = event.pointer.pointer_id;
+                if let Some(tap) = self.taps.iter_mut().find(|state| state.pointer_id == p_id) {
+                    tap.up_time = event.state.time;
+                    event.state.count = tap.count;
+                }
+                PointerEvent::Up(event)
+            }
+            PointerEvent::Move(PointerUpdate {
+                pointer,
+                mut current,
+                mut coalesced,
+                mut predicted,
+            }) => {
+                if let Some(TapState { count, .. }) = self
+                    .taps
+                    .iter()
+                    .find(
+                        |TapState {
+                             pointer_id,
+                             down_time,
+                             up_time,
+                             ..
+                         }| {
+                            *pointer_id == pointer.pointer_id && down_time == up_time
+                        },
+                    )
+                    .cloned()
+                {
+                    current.count = count;
+                    for event in coalesced.iter_mut() {
+                        event.count = count;
+                    }
+                    for event in predicted.iter_mut() {
+                        event.count = count;
+                    }
+                    PointerEvent::Move(PointerUpdate {
+                        pointer,
+                        current,
+                        coalesced,
+                        predicted,
+                    })
+                } else {
+                    PointerEvent::Move(PointerUpdate {
+                        pointer,
+                        current,
+                        coalesced,
+                        predicted,
+                    })
+                }
+            }
+            PointerEvent::Cancel(p) => {
+                self.taps
+                    .retain(|TapState { pointer_id, .. }| *pointer_id != p.pointer_id);
+                PointerEvent::Cancel(p)
+            }
+            PointerEvent::Leave(p) => {
+                self.taps
+                    .retain(|TapState { pointer_id, .. }| *pointer_id != p.pointer_id);
+                PointerEvent::Leave(p)
+            }
+            e
+            @ (PointerEvent::Enter(..) | PointerEvent::Scroll(..) | PointerEvent::Gesture(..)) => e,
+        }
+    }
+
+    /// Clear expired taps.
+    ///
+    /// `t` is the timestamp of the last received event, in the caller's
+    /// monotonic clock domain shared by every event the reducer sees.
+    fn clear_expired(&mut self, t: u64) {
+        self.taps.retain(
+            |TapState {
+                 down_time, up_time, ..
+             }| { down_time == up_time || (up_time + 500_000_000) > t },
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dpi::PhysicalPosition;
+    use ui_events::ScrollDelta;
+    use ui_events::pointer::PointerButton;
+
+    use super::*;
+
+    /// `BTN_LEFT` from `linux/input-event-codes.h`.
+    const BTN_LEFT: u32 = 0x110;
+
+    fn motion(x: f64, y: f64) -> Event {
+        Event::Motion {
+            time: 0,
+            surface_x: x,
+            surface_y: y,
+        }
+    }
+
+    fn button(code: u32, state: ButtonState) -> Event {
+        Event::Button {
+            serial: 0,
+            time: 0,
+            button: code,
+            state: WEnum::Value(state),
+        }
+    }
+
+    fn axis_source(source: wl_pointer::AxisSource) -> Event {
+        Event::AxisSource {
+            axis_source: WEnum::Value(source),
+        }
+    }
+
+    #[test]
+    fn motion_uses_caller_time_scale_and_scaled_position() {
+        let mut reducer = PointerEventReducer::default();
+        let events = reducer.reduce(2.0, &motion(10.0, 20.0), 42);
+
+        assert_eq!(events.len(), 1);
+        let PointerEvent::Move(update) = &events[0] else {
+            panic!("expected a pointer move, got {:?}", events[0]);
+        };
+        assert!(update.pointer.is_primary_pointer());
+        assert_eq!(update.current.time, 42);
+        assert_eq!(update.current.scale_factor, 2.0);
+        assert_eq!(
+            update.current.position,
+            PhysicalPosition { x: 20.0, y: 40.0 }
+        );
+    }
+
+    #[test]
+    fn button_press_release_tracks_state_and_click_count() {
+        let mut reducer = PointerEventReducer::default();
+
+        let down = reducer.reduce(1.0, &button(BTN_LEFT, ButtonState::Pressed), 1_000);
+        let up = reducer.reduce(1.0, &button(BTN_LEFT, ButtonState::Released), 2_000);
+        let down_again = reducer.reduce(1.0, &button(BTN_LEFT, ButtonState::Pressed), 3_000);
+
+        let PointerEvent::Down(first) = &down[0] else {
+            panic!("expected a pointer down");
+        };
+        assert_eq!(first.button, Some(PointerButton::Primary));
+        assert!(first.state.buttons.contains(PointerButton::Primary));
+        assert_eq!(first.state.count, 1);
+
+        let PointerEvent::Up(released) = &up[0] else {
+            panic!("expected a pointer up");
+        };
+        assert_eq!(released.button, Some(PointerButton::Primary));
+        assert!(!released.state.buttons.contains(PointerButton::Primary));
+        assert_eq!(released.state.count, 1);
+
+        let PointerEvent::Down(second) = &down_again[0] else {
+            panic!("expected a second pointer down");
+        };
+        assert_eq!(second.state.count, 2);
+    }
+
+    #[test]
+    fn unknown_button_keeps_button_none_but_still_emits() {
+        let mut reducer = PointerEventReducer::default();
+        // `BTN_TOUCH` (0x14a) has no `PointerButton` mapping.
+        let down = reducer.reduce(1.0, &button(0x14a, ButtonState::Pressed), 1);
+
+        let PointerEvent::Down(event) = &down[0] else {
+            panic!("expected a pointer down");
+        };
+        assert_eq!(event.button, None);
+        assert!(event.state.buttons.is_empty());
+    }
+
+    #[test]
+    fn wheel_scroll_accumulates_and_flushes_on_frame() {
+        let mut reducer = PointerEventReducer::default();
+
+        assert!(
+            reducer
+                .reduce(1.0, &axis_source(wl_pointer::AxisSource::Wheel), 1)
+                .is_empty()
+        );
+        assert!(
+            reducer
+                .reduce(
+                    1.0,
+                    &Event::AxisValue120 {
+                        axis: WEnum::Value(Axis::VerticalScroll),
+                        value120: 240,
+                    },
+                    1,
+                )
+                .is_empty()
+        );
+
+        let flushed = reducer.reduce(1.0, &Event::Frame, 1);
+        let PointerEvent::Scroll(scroll) = &flushed[0] else {
+            panic!("expected a scroll on frame");
+        };
+        assert_eq!(scroll.delta, ScrollDelta::LineDelta(0.0, 2.0));
+        assert_eq!(scroll.state.time, 1);
+    }
+
+    #[test]
+    fn finger_scroll_is_scaled_pixel_delta() {
+        let mut reducer = PointerEventReducer::default();
+
+        let _ = reducer.reduce(2.0, &axis_source(wl_pointer::AxisSource::Finger), 1);
+        let _ = reducer.reduce(
+            2.0,
+            &Event::Axis {
+                time: 0,
+                axis: WEnum::Value(Axis::VerticalScroll),
+                value: 10.0,
+            },
+            1,
+        );
+
+        let flushed = reducer.reduce(2.0, &Event::Frame, 1);
+        let PointerEvent::Scroll(scroll) = &flushed[0] else {
+            panic!("expected a scroll on frame");
+        };
+        assert_eq!(
+            scroll.delta,
+            ScrollDelta::PixelDelta(PhysicalPosition { x: 0.0, y: 20.0 })
+        );
+    }
+
+    #[test]
+    fn enter_records_serial_and_scaled_position() {
+        let mut reducer = PointerEventReducer::default();
+        reducer.primary_state.scale_factor = 2.0;
+
+        let event = reducer.enter(7, 3.0, 4.0);
+
+        assert!(matches!(event, PointerEvent::Enter(_)));
+        assert_eq!(reducer.enter_serial(), Some(7));
+        assert_eq!(
+            reducer.primary_state.position,
+            PhysicalPosition { x: 6.0, y: 8.0 }
+        );
+    }
+
+    #[test]
+    fn leave_clears_serial() {
+        let mut reducer = PointerEventReducer::default();
+        let _ = reducer.enter(7, 0.0, 0.0);
+
+        let event = reducer.leave();
+
+        assert!(matches!(event, PointerEvent::Leave(_)));
+        assert_eq!(reducer.enter_serial(), None);
+    }
+
+    #[test]
+    fn legacy_pointer_emits_scroll_per_axis_without_frame() {
+        let mut reducer = PointerEventReducer::for_version(3);
+
+        let events = reducer.reduce(
+            1.0,
+            &Event::Axis {
+                time: 0,
+                axis: WEnum::Value(Axis::VerticalScroll),
+                value: 12.0,
+            },
+            1,
+        );
+
+        let PointerEvent::Scroll(scroll) = &events[0] else {
+            panic!("expected a scroll without a frame");
+        };
+        assert_eq!(
+            scroll.delta,
+            ScrollDelta::PixelDelta(PhysicalPosition { x: 0.0, y: 12.0 })
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "timestamps must be monotonic nanoseconds")]
+    fn non_monotonic_time_panics_in_debug() {
+        let mut reducer = PointerEventReducer::default();
+        let _ = reducer.reduce(1.0, &motion(1.0, 1.0), 2_000);
+        let _ = reducer.reduce(1.0, &motion(2.0, 2.0), 1_000);
+    }
+}

--- a/ui-events-wayland/src/seat.rs
+++ b/ui-events-wayland/src/seat.rs
@@ -1,0 +1,395 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Aggregates a seat's per-device reducers behind one `wl_seat`.
+//!
+//! A Wayland `wl_seat` groups the input devices a user operates together —
+//! typically a pointer, a keyboard, and a touchscreen — and advertises which of
+//! them it has through its `capabilities` event. [`SeatReducer`] tracks those
+//! capabilities and owns the matching per-device reducers
+//! ([`PointerEventReducer`], [`KeyboardEventReducer`], and
+//! [`TouchEventReducer`]), so a consumer can route every event for a seat
+//! through one object and receive a uniform [`SeatEventTranslation`] stream of
+//! [`PointerEvent`]s and [`KeyboardEvent`]s.
+//!
+//! Feed the seat's own events to [`reduce_seat`] and each device's events to
+//! [`reduce_pointer`], [`reduce_keyboard`], or [`reduce_touch`]. A device
+//! reducer is created the first time it is needed and dropped when its
+//! capability is withdrawn, so losing a device clears its transient state (held
+//! buttons, pressed keys) instead of leaving it stuck.
+//!
+//! Pointer gestures (`zwp_pointer_gestures_v1`) and tablet tools
+//! (`zwp_tablet_v2`) are exposed through their own globals rather than as
+//! `wl_seat` capabilities, so they are outside this aggregation. Drive
+//! [`crate::gesture`] and [`crate::tablet`] directly and wrap their
+//! [`PointerEvent`]s in [`SeatEventTranslation::Pointer`] to place them on the
+//! same stream.
+//!
+//! [`reduce_seat`]: SeatReducer::reduce_seat
+//! [`reduce_pointer`]: SeatReducer::reduce_pointer
+//! [`reduce_keyboard`]: SeatReducer::reduce_keyboard
+//! [`reduce_touch`]: SeatReducer::reduce_touch
+//! [`KeyboardEvent`]: ui_events::keyboard::KeyboardEvent
+//! [`PointerEvent`]: ui_events::pointer::PointerEvent
+
+use ui_events::keyboard::KeyboardEvent;
+use ui_events::pointer::PointerEvent;
+use wayland_client::WEnum;
+use wayland_client::protocol::wl_seat::Capability;
+use wayland_client::protocol::{wl_keyboard, wl_pointer, wl_seat, wl_touch};
+
+use crate::keyboard::KeyboardEventReducer;
+use crate::pointer::PointerEventReducer;
+use crate::touch::TouchEventReducer;
+
+/// The input devices a `wl_seat` currently advertises.
+///
+/// Produced from a `wl_seat::capabilities` event by [`SeatReducer::reduce_seat`]
+/// and readable through [`SeatReducer::capabilities`].
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct SeatCapabilities {
+    /// Whether the seat has a pointer, such as a mouse or touchpad.
+    pub pointer: bool,
+    /// Whether the seat has one or more keyboards.
+    pub keyboard: bool,
+    /// Whether the seat has a touchscreen.
+    pub touch: bool,
+}
+
+/// A [`ui-events`] event produced by a [`SeatReducer`].
+///
+/// This unifies the two event families a seat's devices produce, mirroring the
+/// translation enum of the other adapters.
+///
+/// [`ui-events`]: https://docs.rs/ui-events/
+#[derive(Debug)]
+pub enum SeatEventTranslation {
+    /// A keyboard event from the seat's keyboard.
+    Keyboard(KeyboardEvent),
+    /// A pointer event from the seat's pointer or touchscreen.
+    Pointer(PointerEvent),
+}
+
+/// Aggregates a `wl_seat`'s pointer, keyboard, and touch reducers.
+///
+/// Keep one instance per seat. Call [`reduce_seat`] with the seat's own events
+/// to track its [`capabilities`], and [`reduce_pointer`], [`reduce_keyboard`],
+/// and [`reduce_touch`] with the corresponding device events; each returns the
+/// translated [`SeatEventTranslation`]s. See the [module documentation] for the
+/// model.
+///
+/// The device reducers are reachable through [`pointer`], [`keyboard`], and
+/// [`touch`] once created, for reading device state such as the pointer's
+/// [`enter_serial`] or the keyboard's [`repeat_info`].
+///
+/// [`reduce_seat`]: SeatReducer::reduce_seat
+/// [`reduce_pointer`]: SeatReducer::reduce_pointer
+/// [`reduce_keyboard`]: SeatReducer::reduce_keyboard
+/// [`reduce_touch`]: SeatReducer::reduce_touch
+/// [`capabilities`]: SeatReducer::capabilities
+/// [`pointer`]: SeatReducer::pointer
+/// [`keyboard`]: SeatReducer::keyboard
+/// [`touch`]: SeatReducer::touch
+/// [`enter_serial`]: PointerEventReducer::enter_serial
+/// [`repeat_info`]: KeyboardEventReducer::repeat_info
+/// [module documentation]: self
+#[derive(Debug, Default)]
+pub struct SeatReducer {
+    /// The bound `wl_seat` version used to construct the pointer reducer;
+    /// `None` selects the frame-batched [`Default`].
+    version: Option<u32>,
+    /// Capabilities last advertised by the seat.
+    capabilities: SeatCapabilities,
+    /// Pointer reducer, created on the first pointer event.
+    pointer: Option<PointerEventReducer>,
+    /// Keyboard reducer, created on the first keyboard event.
+    keyboard: Option<KeyboardEventReducer>,
+    /// Touch reducer, created on the first touch event.
+    touch: Option<TouchEventReducer>,
+}
+
+impl SeatReducer {
+    /// Create a reducer for a `wl_seat` bound at the given protocol `version`.
+    ///
+    /// A seat's `wl_pointer`, `wl_keyboard`, and `wl_touch` inherit the seat's
+    /// version. The version currently only affects the pointer reducer's scroll
+    /// batching: `wl_pointer` version 5 introduced the `frame` event that groups
+    /// a scroll's axes, so earlier pointers emit a scroll per axis event (see
+    /// [`PointerEventReducer::for_version`]). The [`Default`] reducer assumes
+    /// frame batching, which is correct for every `wl_pointer` from version 5 on.
+    pub fn for_version(version: u32) -> Self {
+        Self {
+            version: Some(version),
+            ..Self::default()
+        }
+    }
+
+    /// The capabilities most recently advertised by the seat.
+    ///
+    /// This reflects the last `wl_seat::capabilities` event passed to
+    /// [`reduce_seat`](Self::reduce_seat); it is all-`false` until one arrives,
+    /// independent of which device reducers have been created by routing events.
+    pub fn capabilities(&self) -> SeatCapabilities {
+        self.capabilities
+    }
+
+    /// The pointer reducer, once a pointer event has been routed to it.
+    ///
+    /// Useful for reading pointer state such as
+    /// [`PointerEventReducer::enter_serial`].
+    pub fn pointer(&self) -> Option<&PointerEventReducer> {
+        self.pointer.as_ref()
+    }
+
+    /// The keyboard reducer, once a keyboard event has been routed to it.
+    ///
+    /// Useful for reading keyboard state such as
+    /// [`KeyboardEventReducer::repeat_info`] and
+    /// [`KeyboardEventReducer::modifiers`].
+    pub fn keyboard(&self) -> Option<&KeyboardEventReducer> {
+        self.keyboard.as_ref()
+    }
+
+    /// The touch reducer, once a touch event has been routed to it.
+    pub fn touch(&self) -> Option<&TouchEventReducer> {
+        self.touch.as_ref()
+    }
+
+    /// Process a `wl_seat` event, returning the seat's current capabilities.
+    ///
+    /// A `capabilities` event updates the tracked [`SeatCapabilities`]; when a
+    /// capability is withdrawn, the corresponding device reducer is dropped so
+    /// its transient state does not persist across the device's removal. Other
+    /// `wl_seat` events (such as `name`) leave the capabilities unchanged.
+    pub fn reduce_seat(&mut self, event: &wl_seat::Event) -> SeatCapabilities {
+        if let wl_seat::Event::Capabilities { capabilities } = event {
+            let capabilities = seat_capabilities(*capabilities);
+            self.capabilities = capabilities;
+            if !capabilities.pointer {
+                self.pointer = None;
+            }
+            if !capabilities.keyboard {
+                self.keyboard = None;
+            }
+            if !capabilities.touch {
+                self.touch = None;
+            }
+        }
+        self.capabilities
+    }
+
+    /// Process a `wl_pointer` event, returning any resulting pointer events.
+    ///
+    /// `scale_factor` and `time` are forwarded to [`PointerEventReducer::reduce`];
+    /// see it for their meaning and requirements. The pointer reducer is created
+    /// on first use.
+    pub fn reduce_pointer(
+        &mut self,
+        scale_factor: f64,
+        event: &wl_pointer::Event,
+        time: u64,
+    ) -> Vec<SeatEventTranslation> {
+        let version = self.version;
+        self.pointer
+            .get_or_insert_with(|| match version {
+                Some(version) => PointerEventReducer::for_version(version),
+                None => PointerEventReducer::default(),
+            })
+            .reduce(scale_factor, event, time)
+            .into_iter()
+            .map(SeatEventTranslation::Pointer)
+            .collect()
+    }
+
+    /// Process a `wl_keyboard` event, returning any resulting keyboard event.
+    ///
+    /// See [`KeyboardEventReducer::reduce`]. The keyboard reducer is created on
+    /// first use.
+    pub fn reduce_keyboard(&mut self, event: &wl_keyboard::Event) -> Option<SeatEventTranslation> {
+        self.keyboard
+            .get_or_insert_with(KeyboardEventReducer::default)
+            .reduce(event)
+            .map(SeatEventTranslation::Keyboard)
+    }
+
+    /// Process a `wl_touch` event, returning any resulting pointer events.
+    ///
+    /// `scale_factor` and `time` are forwarded to [`TouchEventReducer::reduce`];
+    /// see it for their meaning and requirements. The touch reducer is created
+    /// on first use.
+    pub fn reduce_touch(
+        &mut self,
+        scale_factor: f64,
+        event: &wl_touch::Event,
+        time: u64,
+    ) -> Vec<SeatEventTranslation> {
+        self.touch
+            .get_or_insert_with(TouchEventReducer::default)
+            .reduce(scale_factor, event, time)
+            .into_iter()
+            .map(SeatEventTranslation::Pointer)
+            .collect()
+    }
+}
+
+/// Convert a `wl_seat` capability bitmask into [`SeatCapabilities`].
+///
+/// Bits from a newer protocol version are unknown to the locked bindings, which
+/// makes the whole mask deserialize as [`WEnum::Unknown`]. Truncating to the
+/// known bits keeps the recognized capabilities rather than discarding them all.
+fn seat_capabilities(capabilities: WEnum<Capability>) -> SeatCapabilities {
+    let capabilities = match capabilities {
+        WEnum::Value(capabilities) => capabilities,
+        WEnum::Unknown(bits) => Capability::from_bits_truncate(bits),
+    };
+    SeatCapabilities {
+        pointer: capabilities.contains(Capability::Pointer),
+        keyboard: capabilities.contains(Capability::Keyboard),
+        touch: capabilities.contains(Capability::Touch),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ui_events::pointer::PointerEvent;
+    use wayland_client::WEnum;
+    use wayland_client::protocol::wl_keyboard::{self, KeyState as WlKeyState};
+    use wayland_client::protocol::wl_pointer;
+    use wayland_client::protocol::wl_seat::{self, Capability};
+    use wayland_client::protocol::wl_touch;
+
+    use super::{SeatCapabilities, SeatEventTranslation, SeatReducer, seat_capabilities};
+
+    /// `KEY_A` evdev scancode, a convenient non-modifier key.
+    const KEY_A: u32 = 30;
+
+    fn pointer_motion(x: f64, y: f64) -> wl_pointer::Event {
+        wl_pointer::Event::Motion {
+            time: 0,
+            surface_x: x,
+            surface_y: y,
+        }
+    }
+
+    fn key_press(key: u32) -> wl_keyboard::Event {
+        wl_keyboard::Event::Key {
+            serial: 0,
+            time: 0,
+            key,
+            state: WEnum::Value(WlKeyState::Pressed),
+        }
+    }
+
+    fn capabilities(capabilities: WEnum<Capability>) -> wl_seat::Event {
+        wl_seat::Event::Capabilities { capabilities }
+    }
+
+    #[test]
+    fn seat_capabilities_reads_known_bits() {
+        assert_eq!(
+            seat_capabilities(WEnum::Value(Capability::Pointer | Capability::Touch)),
+            SeatCapabilities {
+                pointer: true,
+                keyboard: false,
+                touch: true,
+            }
+        );
+        assert_eq!(
+            seat_capabilities(WEnum::Value(Capability::empty())),
+            SeatCapabilities::default()
+        );
+    }
+
+    #[test]
+    fn seat_capabilities_ignores_unknown_bits() {
+        // Bit `0b1000` is not a known capability; truncating must keep the
+        // pointer (`0b1`) and keyboard (`0b10`) bits rather than dropping all.
+        assert_eq!(
+            seat_capabilities(WEnum::Unknown(0b1011)),
+            SeatCapabilities {
+                pointer: true,
+                keyboard: true,
+                touch: false,
+            }
+        );
+    }
+
+    #[test]
+    fn reduce_seat_tracks_capabilities() {
+        let mut seat = SeatReducer::default();
+
+        let caps = seat.reduce_seat(&capabilities(WEnum::Value(
+            Capability::Pointer | Capability::Keyboard,
+        )));
+
+        let expected = SeatCapabilities {
+            pointer: true,
+            keyboard: true,
+            touch: false,
+        };
+        assert_eq!(caps, expected);
+        assert_eq!(seat.capabilities(), expected);
+    }
+
+    #[test]
+    fn pointer_events_are_routed_and_wrapped() {
+        let mut seat = SeatReducer::default();
+
+        let out = seat.reduce_pointer(1.0, &pointer_motion(4.0, 5.0), 1_000);
+
+        assert_eq!(out.len(), 1);
+        assert!(matches!(
+            out[0],
+            SeatEventTranslation::Pointer(PointerEvent::Move(_))
+        ));
+        // The reducer is created on first use and then exposed.
+        assert!(seat.pointer().is_some());
+    }
+
+    #[test]
+    fn for_version_routes_pointer_events() {
+        // A pre-frame pointer version still produces a working reducer.
+        let mut seat = SeatReducer::for_version(1);
+
+        let out = seat.reduce_pointer(1.0, &pointer_motion(0.0, 0.0), 10);
+
+        assert_eq!(out.len(), 1);
+        assert!(seat.pointer().is_some());
+    }
+
+    #[test]
+    fn keyboard_events_are_routed_and_wrapped() {
+        let mut seat = SeatReducer::default();
+
+        let out = seat.reduce_keyboard(&key_press(KEY_A));
+
+        assert!(matches!(out, Some(SeatEventTranslation::Keyboard(_))));
+        assert!(seat.keyboard().is_some());
+    }
+
+    #[test]
+    fn touch_events_are_routed() {
+        let mut seat = SeatReducer::default();
+
+        // A bare `frame` with no active contacts flushes nothing, but routing it
+        // still creates the touch reducer.
+        let out = seat.reduce_touch(1.0, &wl_touch::Event::Frame, 1_000);
+
+        assert!(out.is_empty());
+        assert!(seat.touch().is_some());
+    }
+
+    #[test]
+    fn lost_capability_drops_reducer() {
+        let mut seat = SeatReducer::default();
+
+        // Route a pointer event so the pointer reducer exists.
+        let _ = seat.reduce_pointer(1.0, &pointer_motion(1.0, 1.0), 1_000);
+        assert!(seat.pointer().is_some());
+
+        // Losing the pointer capability drops the reducer and its state.
+        let caps = seat.reduce_seat(&capabilities(WEnum::Value(Capability::empty())));
+        assert!(!caps.pointer);
+        assert!(seat.pointer().is_none());
+    }
+}

--- a/ui-events-wayland/src/seat.rs
+++ b/ui-events-wayland/src/seat.rs
@@ -32,6 +32,8 @@
 //! [`KeyboardEvent`]: ui_events::keyboard::KeyboardEvent
 //! [`PointerEvent`]: ui_events::pointer::PointerEvent
 
+use alloc::vec::Vec;
+
 use ui_events::keyboard::KeyboardEvent;
 use ui_events::pointer::PointerEvent;
 use wayland_client::WEnum;

--- a/ui-events-wayland/src/tablet.rs
+++ b/ui-events-wayland/src/tablet.rs
@@ -1,0 +1,570 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Reduces `zwp_tablet_tool_v2` event streams into pen [`PointerEvent`]s.
+//!
+//! [`TabletToolReducer`] mirrors the stateful-reducer pattern of the other
+//! adapters: feed it each `zwp_tablet_tool_v2` event for one tablet tool together
+//! with a caller-provided monotonic timestamp, and it tracks the tool's
+//! [`PointerState`] and emits [`PointerEvent`]s. Keep one reducer per tool; the
+//! tool is reported as the primary pointer of its [`PointerType`].
+//!
+//! ## Frame batching
+//!
+//! Like `wl_touch`, the tablet protocol groups the events that belong to one
+//! logical update — motion together with its pressure, tilt, and slider axes, or
+//! a proximity change together with the motion that positions it — between
+//! `frame` events, and the order within a frame is unspecified. The reducer
+//! therefore accumulates the tool's state as the events arrive and emits the
+//! resulting [`PointerEvent`]s only on `frame`, so position and axes are fully
+//! assembled first. Within a frame a tip press or release supersedes a bare
+//! move, since it already carries the freshest state.
+//!
+//! ## Tools, contact, and axes
+//!
+//! The `type` event sets the [`PointerType`]: the pen-like tools report as
+//! [`PointerType::Pen`], the puck-style mouse and lens tools as
+//! [`PointerType::Mouse`], and the finger tool as [`PointerType::Touch`] (see
+//! [`mapping::pointer_type_from_tool`]). The tool tip's `down`/`up` become
+//! [`PointerEvent::Down`]/[`PointerEvent::Up`] carrying [`PointerButton::Primary`],
+//! or [`PointerButton::PenEraser`] for an eraser tool. Stylus barrel buttons are
+//! mapped through [`mapping::pen_button_from_evdev`]. `pressure` populates
+//! [`PointerState::pressure`] (falling back to the active-unknown `0.5` for tools
+//! that report no pressure), `slider` populates
+//! [`PointerState::tangential_pressure`], and `tilt` populates
+//! [`PointerState::orientation`]. `proximity_in`/`proximity_out` become
+//! [`PointerEvent::Enter`]/[`PointerEvent::Leave`], and the serial of the most
+//! recent `proximity_in` is exposed through
+//! [`TabletToolReducer::proximity_serial`] for `set_cursor`.
+//!
+//! The tool's `distance` (hover height), `rotation` (barrel twist), and `wheel`
+//! axes have no [`ui-events`] representation and are ignored, as is the
+//! descriptive lifecycle (`capability`, `hardware_serial`, `hardware_id_wacom`,
+//! `done`, `removed`), which the consumer handles when managing tools. The twist
+//! omission matches the web backend, which likewise does not map Pointer Events
+//! `twist`.
+//!
+//! Reducers built on these helpers take a caller-provided monotonic nanosecond
+//! timestamp, not Wayland's 32-bit millisecond event timestamps, so input shares
+//! one clock domain with frame sampling and timers.
+//!
+//! [`PointerState`]: ui_events::pointer::PointerState
+//! [`PointerState::pressure`]: ui_events::pointer::PointerState::pressure
+//! [`PointerState::tangential_pressure`]: ui_events::pointer::PointerState::tangential_pressure
+//! [`PointerState::orientation`]: ui_events::pointer::PointerState::orientation
+//! [`PointerType`]: ui_events::pointer::PointerType
+//! [`PointerType::Pen`]: ui_events::pointer::PointerType::Pen
+//! [`PointerType::Mouse`]: ui_events::pointer::PointerType::Mouse
+//! [`PointerType::Touch`]: ui_events::pointer::PointerType::Touch
+//! [`PointerButton::Primary`]: ui_events::pointer::PointerButton::Primary
+//! [`PointerButton::PenEraser`]: ui_events::pointer::PointerButton::PenEraser
+//! [`ui-events`]: https://docs.rs/ui-events/
+
+use ui_events::pointer::{
+    PointerButton, PointerButtonEvent, PointerEvent, PointerInfo, PointerState, PointerType,
+    PointerUpdate,
+};
+use wayland_client::WEnum;
+use wayland_protocols::wp::tablet::zv2::client::zwp_tablet_tool_v2::{ButtonState, Event, Type};
+
+use crate::mapping::{self, ToolType};
+use crate::pointer::TapCounter;
+
+/// Pressure reported while a tool is in contact but reports no pressure axis.
+///
+/// Tools without a pressure sensor follow the `ui-events` convention of `0.5`
+/// while the tip is down.
+const ACTIVE_PRESSURE: f32 = 0.5;
+/// Pressure reported once the tool tip leaves the surface.
+const RELEASED_PRESSURE: f32 = 0.0;
+
+/// The per-frame changes to flush on the next `frame`.
+#[derive(Debug, Default)]
+struct PendingFrame {
+    /// The tool entered proximity (`proximity_in`).
+    enter: bool,
+    /// The tool left proximity (`proximity_out`).
+    leave: bool,
+    /// The tool's position or an axis changed (`motion`, `pressure`, `tilt`,
+    /// `slider`).
+    motion: bool,
+    /// The tool tip touched the surface (`down`).
+    tip_down: bool,
+    /// The tool tip left the surface (`up`).
+    tip_up: bool,
+    /// Barrel-button changes, each `(button, pressed)`, in arrival order. The
+    /// button is `None` for a code with no [`PointerButton`] mapping.
+    buttons: Vec<(Option<PointerButton>, bool)>,
+}
+
+/// Reduces a `zwp_tablet_tool_v2` event stream into [`PointerEvent`]s.
+///
+/// Keep one reducer per tablet tool and call [`reduce`] with each event. See the
+/// [module documentation] for the batching, tool, axis, and timing model.
+///
+/// [`reduce`]: TabletToolReducer::reduce
+/// [module documentation]: self
+#[derive(Debug)]
+pub struct TabletToolReducer {
+    /// Accumulated state of the tool.
+    state: PointerState,
+    /// Pointer type derived from the `type` event; [`PointerType::Pen`] until one
+    /// arrives.
+    pointer_type: PointerType,
+    /// The [`PointerButton`] the tool tip maps to, derived from the `type` event.
+    tip_button: PointerButton,
+    /// Whether the tool is currently between `proximity_in` and `proximity_out`.
+    in_proximity: bool,
+    /// Serial of the most recent `proximity_in`, for `set_cursor`.
+    proximity_serial: Option<u32>,
+    /// Whether the tool has ever reported a `pressure` axis, so the tip-down
+    /// fallback pressure is only used by tools without a pressure sensor.
+    pressure_reported: bool,
+    /// Per-frame changes accumulated since the last `frame`.
+    pending: PendingFrame,
+    /// Click counter, shared with the pointer reducer.
+    counter: TapCounter,
+    /// Last caller-provided timestamp, for the monotonicity debug assertion.
+    last_seen_time: Option<u64>,
+}
+
+impl Default for TabletToolReducer {
+    fn default() -> Self {
+        Self {
+            state: PointerState::default(),
+            pointer_type: PointerType::Pen,
+            tip_button: PointerButton::Primary,
+            in_proximity: false,
+            proximity_serial: None,
+            pressure_reported: false,
+            pending: PendingFrame::default(),
+            counter: TapCounter::default(),
+            last_seen_time: None,
+        }
+    }
+}
+
+impl TabletToolReducer {
+    /// The serial of the most recent `proximity_in`, while the tool is in
+    /// proximity.
+    ///
+    /// `zwp_tablet_tool_v2::set_cursor` requires the serial of the latest
+    /// `proximity_in`; consumers read it from here. It is cleared on
+    /// `proximity_out`.
+    pub fn proximity_serial(&self) -> Option<u32> {
+        self.proximity_serial
+    }
+
+    /// Reduce a single `zwp_tablet_tool_v2` [`Event`] into zero or more
+    /// [`PointerEvent`]s.
+    ///
+    /// `time` is a monotonic nanosecond timestamp in the consumer's clock
+    /// domain, stamped into the [`PointerState`] of every event this call
+    /// produces; Wayland's own 32-bit millisecond event timestamps are
+    /// deliberately not used as the clock. `scale_factor` converts surface-local
+    /// logical coordinates to physical pixels.
+    ///
+    /// Proximity, motion, axis, tip, and button events update the tool's state
+    /// but emit nothing; the accumulated [`PointerEvent`]s are returned from the
+    /// `frame` event that closes the batch.
+    ///
+    /// `time` must be monotonic across calls; a regression trips a
+    /// `debug_assert!`, since click detection measures durations in nanoseconds.
+    pub fn reduce(&mut self, scale_factor: f64, event: &Event, time: u64) -> Vec<PointerEvent> {
+        self.check_time_monotonic(time);
+        self.state.time = time;
+        self.state.scale_factor = scale_factor;
+
+        match event {
+            Event::Type { tool_type } => self.set_tool(*tool_type),
+            // `proximity_in` carries `tablet` and `surface` objects that cannot
+            // be constructed without a live connection, so the
+            // surface-independent logic lives in `proximity_in`.
+            Event::ProximityIn { serial, .. } => self.proximity_in(*serial),
+            Event::ProximityOut => self.pending.leave = true,
+            Event::Down { .. } => self.pending.tip_down = true,
+            Event::Up => self.pending.tip_up = true,
+            Event::Motion { x, y } => self.motion(*x, *y),
+            Event::Pressure { pressure } => self.set_pressure(*pressure),
+            Event::Tilt { tilt_x, tilt_y } => self.set_tilt(*tilt_x, *tilt_y),
+            Event::Slider { position } => self.set_slider(*position),
+            Event::Button { button, state, .. } => self.button(*button, *state),
+            Event::Frame { .. } => return self.flush(scale_factor),
+            // No `ui-events` representation: hover distance, barrel rotation
+            // (twist), and the tool wheel. See the module documentation.
+            Event::Distance { .. } | Event::Rotation { .. } | Event::Wheel { .. } => {}
+            // `Event` is `#[non_exhaustive]`, and the descriptive lifecycle events
+            // (`capability`, `hardware_serial`, `hardware_id_wacom`, `done`,
+            // `removed`) carry no input.
+            _ => {}
+        }
+        Vec::new()
+    }
+
+    /// Handle a `type` event: derive the pointer type and tip button.
+    fn set_tool(&mut self, value: WEnum<Type>) {
+        if let Some(tool) = tool_type_from_protocol(value) {
+            self.pointer_type = mapping::pointer_type_from_tool(tool);
+            self.tip_button = mapping::tip_button_from_tool(tool);
+        }
+    }
+
+    /// Handle a `proximity_in` event: record the serial and mark an enter.
+    ///
+    /// This takes the serial rather than the `proximity_in` event, whose `tablet`
+    /// and `surface` objects cannot be constructed without a live connection, so
+    /// the surface-independent logic stays unit-testable.
+    fn proximity_in(&mut self, serial: u32) {
+        self.in_proximity = true;
+        self.proximity_serial = Some(serial);
+        self.pending.enter = true;
+    }
+
+    /// Handle a `motion` event: update the position from surface-local logical
+    /// coordinates.
+    fn motion(&mut self, x: f64, y: f64) {
+        self.state.position =
+            mapping::physical_position_from_logical(x, y, self.state.scale_factor);
+        self.pending.motion = true;
+    }
+
+    /// Handle a `pressure` event: update the normalized pressure.
+    fn set_pressure(&mut self, pressure: u32) {
+        self.pressure_reported = true;
+        self.state.pressure = mapping::pressure_from_normalized(pressure);
+        self.pending.motion = true;
+    }
+
+    /// Handle a `tilt` event: update the orientation.
+    fn set_tilt(&mut self, tilt_x: f64, tilt_y: f64) {
+        self.state.orientation = mapping::pointer_orientation_from_tilt_degrees(tilt_x, tilt_y);
+        self.pending.motion = true;
+    }
+
+    /// Handle a `slider` event: update the tangential pressure.
+    fn set_slider(&mut self, position: i32) {
+        self.state.tangential_pressure = mapping::tangential_pressure_from_slider(position);
+        self.pending.motion = true;
+    }
+
+    /// Handle a `button` event: record the barrel-button change for the frame.
+    fn button(&mut self, code: u32, state: WEnum<ButtonState>) {
+        let button = mapping::pen_button_from_evdev(code);
+        match state {
+            WEnum::Value(ButtonState::Pressed) => self.pending.buttons.push((button, true)),
+            WEnum::Value(ButtonState::Released) => self.pending.buttons.push((button, false)),
+            // Unknown button state.
+            _ => {}
+        }
+    }
+
+    /// Emit the changes accumulated since the last `frame`.
+    fn flush(&mut self, scale_factor: f64) -> Vec<PointerEvent> {
+        let pending = core::mem::take(&mut self.pending);
+        let mut events = Vec::new();
+
+        if pending.enter {
+            let event = PointerEvent::Enter(self.pointer_info());
+            events.push(self.counter.attach_count(scale_factor, event));
+        }
+
+        // A tip press or release carries the freshest position and axes, so it
+        // supersedes a bare move within the same frame.
+        if pending.tip_down {
+            self.state.buttons.insert(self.tip_button);
+            if !self.pressure_reported {
+                self.state.pressure = ACTIVE_PRESSURE;
+            }
+            let event = self.button_event(Some(self.tip_button), true);
+            events.push(self.counter.attach_count(scale_factor, event));
+        } else if pending.tip_up {
+            self.state.buttons.remove(self.tip_button);
+            self.state.pressure = RELEASED_PRESSURE;
+            let event = self.button_event(Some(self.tip_button), false);
+            events.push(self.counter.attach_count(scale_factor, event));
+        } else if pending.motion {
+            let event = self.move_event();
+            events.push(self.counter.attach_count(scale_factor, event));
+        }
+
+        for &(button, pressed) in &pending.buttons {
+            if let Some(button) = button {
+                if pressed {
+                    self.state.buttons.insert(button);
+                } else {
+                    self.state.buttons.remove(button);
+                }
+            }
+            let event = self.button_event(button, pressed);
+            events.push(self.counter.attach_count(scale_factor, event));
+        }
+
+        if pending.leave {
+            let event = PointerEvent::Leave(self.pointer_info());
+            events.push(self.counter.attach_count(scale_factor, event));
+            self.reset_on_leave();
+        }
+
+        events
+    }
+
+    /// The [`PointerInfo`] for this tool, reported as the primary pointer of its
+    /// type.
+    fn pointer_info(&self) -> PointerInfo {
+        mapping::primary_pointer_info(self.pointer_type)
+    }
+
+    /// Build a [`PointerEvent::Down`] or [`PointerEvent::Up`] for `button` with
+    /// the current state.
+    fn button_event(&self, button: Option<PointerButton>, pressed: bool) -> PointerEvent {
+        let event = PointerButtonEvent {
+            button,
+            pointer: self.pointer_info(),
+            state: self.state.clone(),
+        };
+        if pressed {
+            PointerEvent::Down(event)
+        } else {
+            PointerEvent::Up(event)
+        }
+    }
+
+    /// Build a [`PointerEvent::Move`] with the current state.
+    fn move_event(&self) -> PointerEvent {
+        PointerEvent::Move(PointerUpdate {
+            pointer: self.pointer_info(),
+            current: self.state.clone(),
+            coalesced: Vec::new(),
+            predicted: Vec::new(),
+        })
+    }
+
+    /// Reset the per-proximity state after a `proximity_out`, keeping the tool's
+    /// derived type and pressure capability for the next time it enters.
+    fn reset_on_leave(&mut self) {
+        self.in_proximity = false;
+        self.proximity_serial = None;
+        let time = self.state.time;
+        let scale_factor = self.state.scale_factor;
+        self.state = PointerState {
+            time,
+            scale_factor,
+            ..PointerState::default()
+        };
+    }
+
+    /// Debug-assert that caller timestamps do not regress.
+    fn check_time_monotonic(&mut self, time: u64) {
+        if let Some(previous) = self.last_seen_time {
+            debug_assert!(
+                time >= previous,
+                "TabletToolReducer::reduce timestamps must be monotonic nanoseconds"
+            );
+        }
+        self.last_seen_time = Some(time);
+    }
+}
+
+/// Translate a `zwp_tablet_tool_v2::type` value into the neutral [`ToolType`].
+fn tool_type_from_protocol(value: WEnum<Type>) -> Option<ToolType> {
+    match value {
+        WEnum::Value(Type::Pen) => Some(ToolType::Pen),
+        WEnum::Value(Type::Eraser) => Some(ToolType::Eraser),
+        WEnum::Value(Type::Brush) => Some(ToolType::Brush),
+        WEnum::Value(Type::Pencil) => Some(ToolType::Pencil),
+        WEnum::Value(Type::Airbrush) => Some(ToolType::Airbrush),
+        WEnum::Value(Type::Finger) => Some(ToolType::Finger),
+        WEnum::Value(Type::Mouse) => Some(ToolType::Mouse),
+        WEnum::Value(Type::Lens) => Some(ToolType::Lens),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dpi::PhysicalPosition;
+
+    use super::*;
+
+    /// `BTN_STYLUS` from `linux/input-event-codes.h`.
+    const BTN_STYLUS: u32 = 0x14b;
+
+    fn frame() -> Event {
+        Event::Frame { time: 0 }
+    }
+
+    fn motion(x: f64, y: f64) -> Event {
+        Event::Motion { x, y }
+    }
+
+    fn down() -> Event {
+        Event::Down { serial: 0 }
+    }
+
+    fn pressure(value: u32) -> Event {
+        Event::Pressure { pressure: value }
+    }
+
+    fn tilt(tilt_x: f64, tilt_y: f64) -> Event {
+        Event::Tilt { tilt_x, tilt_y }
+    }
+
+    fn slider(position: i32) -> Event {
+        Event::Slider { position }
+    }
+
+    fn tool(tool_type: Type) -> Event {
+        Event::Type {
+            tool_type: WEnum::Value(tool_type),
+        }
+    }
+
+    fn button(code: u32, state: ButtonState) -> Event {
+        Event::Button {
+            serial: 0,
+            button: code,
+            state: WEnum::Value(state),
+        }
+    }
+
+    #[test]
+    fn proximity_in_then_motion_emits_enter_then_move() {
+        let mut reducer = TabletToolReducer::default();
+        // `proximity_in` carries un-constructable objects, so call it directly.
+        reducer.proximity_in(7);
+        let _ = reducer.reduce(2.0, &motion(10.0, 20.0), 5);
+        let events = reducer.reduce(2.0, &frame(), 5);
+
+        assert_eq!(events.len(), 2);
+        let PointerEvent::Enter(enter) = &events[0] else {
+            panic!("expected an enter, got {:?}", events[0]);
+        };
+        assert!(enter.is_primary_pointer());
+        assert_eq!(enter.pointer_type, PointerType::Pen);
+
+        let PointerEvent::Move(update) = &events[1] else {
+            panic!("expected a move, got {:?}", events[1]);
+        };
+        assert_eq!(
+            update.current.position,
+            PhysicalPosition { x: 20.0, y: 40.0 }
+        );
+        assert_eq!(update.current.time, 5);
+        assert_eq!(reducer.proximity_serial(), Some(7));
+    }
+
+    #[test]
+    fn tip_down_then_up_tracks_primary_button_and_pressure() {
+        let mut reducer = TabletToolReducer::default();
+
+        let _ = reducer.reduce(1.0, &down(), 1_000);
+        let down_events = reducer.reduce(1.0, &frame(), 1_000);
+        assert_eq!(down_events.len(), 1);
+        let PointerEvent::Down(d) = &down_events[0] else {
+            panic!("expected a down, got {:?}", down_events[0]);
+        };
+        assert_eq!(d.button, Some(PointerButton::Primary));
+        assert_eq!(d.pointer.pointer_type, PointerType::Pen);
+        assert!(d.state.buttons.contains(PointerButton::Primary));
+        // No pressure axis was reported, so the active-unknown fallback applies.
+        assert_eq!(d.state.pressure, ACTIVE_PRESSURE);
+        assert_eq!(d.state.count, 1);
+
+        let _ = reducer.reduce(1.0, &Event::Up, 2_000);
+        let up_events = reducer.reduce(1.0, &frame(), 2_000);
+        let PointerEvent::Up(u) = &up_events[0] else {
+            panic!("expected an up, got {:?}", up_events[0]);
+        };
+        assert_eq!(u.button, Some(PointerButton::Primary));
+        assert!(!u.state.buttons.contains(PointerButton::Primary));
+        assert_eq!(u.state.pressure, RELEASED_PRESSURE);
+    }
+
+    #[test]
+    fn reported_pressure_overrides_active_default() {
+        let mut reducer = TabletToolReducer::default();
+        let _ = reducer.reduce(1.0, &down(), 1);
+        let _ = reducer.reduce(1.0, &pressure(65535), 1);
+        let events = reducer.reduce(1.0, &frame(), 1);
+
+        // The tip-down and the reported pressure coalesce into a single down.
+        assert_eq!(events.len(), 1);
+        let PointerEvent::Down(d) = &events[0] else {
+            panic!("expected a down, got {:?}", events[0]);
+        };
+        assert!((d.state.pressure - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn tilt_and_slider_populate_orientation_and_tangential_pressure() {
+        let mut reducer = TabletToolReducer::default();
+        let _ = reducer.reduce(1.0, &tilt(30.0, 0.0), 1);
+        let _ = reducer.reduce(1.0, &slider(32768), 1);
+        let events = reducer.reduce(1.0, &frame(), 1);
+
+        assert_eq!(events.len(), 1);
+        let PointerEvent::Move(update) = &events[0] else {
+            panic!("expected a move, got {:?}", events[0]);
+        };
+        // Tilt toward +x aims the azimuth along the x-axis.
+        assert!(update.current.orientation.azimuth.abs() < 1e-5);
+        assert!((update.current.tangential_pressure - 0.5).abs() < 1e-4);
+    }
+
+    #[test]
+    fn eraser_tool_tip_maps_to_pen_eraser() {
+        let mut reducer = TabletToolReducer::default();
+        let _ = reducer.reduce(1.0, &tool(Type::Eraser), 1);
+        let _ = reducer.reduce(1.0, &down(), 1);
+        let events = reducer.reduce(1.0, &frame(), 1);
+
+        let PointerEvent::Down(d) = &events[0] else {
+            panic!("expected a down, got {:?}", events[0]);
+        };
+        assert_eq!(d.button, Some(PointerButton::PenEraser));
+        assert_eq!(d.pointer.pointer_type, PointerType::Pen);
+        assert!(d.state.buttons.contains(PointerButton::PenEraser));
+    }
+
+    #[test]
+    fn barrel_button_press_maps_to_secondary() {
+        let mut reducer = TabletToolReducer::default();
+        let _ = reducer.reduce(1.0, &button(BTN_STYLUS, ButtonState::Pressed), 1);
+        let events = reducer.reduce(1.0, &frame(), 1);
+
+        assert_eq!(events.len(), 1);
+        let PointerEvent::Down(d) = &events[0] else {
+            panic!("expected a down, got {:?}", events[0]);
+        };
+        assert_eq!(d.button, Some(PointerButton::Secondary));
+        assert!(d.state.buttons.contains(PointerButton::Secondary));
+    }
+
+    #[test]
+    fn proximity_out_emits_leave_and_clears_serial() {
+        let mut reducer = TabletToolReducer::default();
+        reducer.proximity_in(3);
+        let _ = reducer.reduce(1.0, &motion(1.0, 1.0), 1);
+        let _ = reducer.reduce(1.0, &frame(), 1);
+
+        let _ = reducer.reduce(1.0, &Event::ProximityOut, 2);
+        let events = reducer.reduce(1.0, &frame(), 2);
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], PointerEvent::Leave(_)));
+        assert_eq!(reducer.proximity_serial(), None);
+    }
+
+    #[test]
+    fn frame_without_changes_emits_nothing() {
+        let mut reducer = TabletToolReducer::default();
+        assert!(reducer.reduce(1.0, &frame(), 1).is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "timestamps must be monotonic nanoseconds")]
+    fn non_monotonic_time_panics_in_debug() {
+        let mut reducer = TabletToolReducer::default();
+        let _ = reducer.reduce(1.0, &frame(), 2_000);
+        let _ = reducer.reduce(1.0, &frame(), 1_000);
+    }
+}

--- a/ui-events-wayland/src/tablet.rs
+++ b/ui-events-wayland/src/tablet.rs
@@ -29,8 +29,8 @@
 //! [`PointerEvent::Down`]/[`PointerEvent::Up`] carrying [`PointerButton::Primary`],
 //! or [`PointerButton::PenEraser`] for an eraser tool. Stylus barrel buttons are
 //! mapped through [`mapping::pen_button_from_evdev`]. `pressure` populates
-//! [`PointerState::pressure`] (falling back to the active-unknown `0.5` for tools
-//! that report no pressure), `slider` populates
+//! [`PointerState::pressure`] (falling back to the active-unknown `0.5` while the
+//! tip is down with no pressure reported for the contact), `slider` populates
 //! [`PointerState::tangential_pressure`], and `tilt` populates
 //! [`PointerState::orientation`]. `proximity_in`/`proximity_out` become
 //! [`PointerEvent::Enter`]/[`PointerEvent::Leave`], and the serial of the most
@@ -119,9 +119,11 @@ pub struct TabletToolReducer {
     in_proximity: bool,
     /// Serial of the most recent `proximity_in`, for `set_cursor`.
     proximity_serial: Option<u32>,
-    /// Whether the tool has ever reported a `pressure` axis, so the tip-down
-    /// fallback pressure is only used by tools without a pressure sensor.
-    pressure_reported: bool,
+    /// Whether a `pressure` value has been reported for the current contact. A
+    /// `pressure` event sets it; lifting the tip or leaving proximity clears it,
+    /// so a tip-down with no reported pressure falls back to the active-unknown
+    /// `ACTIVE_PRESSURE` rather than emitting a stale release-level value.
+    pressure_known: bool,
     /// Per-frame changes accumulated since the last `frame`.
     pending: PendingFrame,
     /// Click counter, shared with the pointer reducer.
@@ -138,7 +140,7 @@ impl Default for TabletToolReducer {
             tip_button: PointerButton::Primary,
             in_proximity: false,
             proximity_serial: None,
-            pressure_reported: false,
+            pressure_known: false,
             pending: PendingFrame::default(),
             counter: TapCounter::default(),
             last_seen_time: None,
@@ -232,7 +234,7 @@ impl TabletToolReducer {
 
     /// Handle a `pressure` event: update the normalized pressure.
     fn set_pressure(&mut self, pressure: u32) {
-        self.pressure_reported = true;
+        self.pressure_known = true;
         self.state.pressure = mapping::pressure_from_normalized(pressure);
         self.pending.motion = true;
     }
@@ -274,7 +276,7 @@ impl TabletToolReducer {
         // supersedes a bare move within the same frame.
         if pending.tip_down {
             self.state.buttons.insert(self.tip_button);
-            if !self.pressure_reported {
+            if !self.pressure_known {
                 self.state.pressure = ACTIVE_PRESSURE;
             }
             let event = self.button_event(Some(self.tip_button), true);
@@ -282,6 +284,8 @@ impl TabletToolReducer {
         } else if pending.tip_up {
             self.state.buttons.remove(self.tip_button);
             self.state.pressure = RELEASED_PRESSURE;
+            // The contact ended; the next tip-down needs its own pressure value.
+            self.pressure_known = false;
             let event = self.button_event(Some(self.tip_button), false);
             events.push(self.counter.attach_count(scale_factor, event));
         } else if pending.motion {
@@ -342,10 +346,11 @@ impl TabletToolReducer {
     }
 
     /// Reset the per-proximity state after a `proximity_out`, keeping the tool's
-    /// derived type and pressure capability for the next time it enters.
+    /// derived type for the next time it enters.
     fn reset_on_leave(&mut self) {
         self.in_proximity = false;
         self.proximity_serial = None;
+        self.pressure_known = false;
         let time = self.state.time;
         let scale_factor = self.state.scale_factor;
         self.state = PointerState {
@@ -495,6 +500,63 @@ mod tests {
             panic!("expected a down, got {:?}", events[0]);
         };
         assert!((d.state.pressure - 1.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn tip_down_after_a_pressure_cycle_falls_back_to_active_pressure() {
+        let mut reducer = TabletToolReducer::default();
+
+        // A first contact reports real pressure.
+        reducer.proximity_in(1);
+        let _ = reducer.reduce(1.0, &down(), 1);
+        let _ = reducer.reduce(1.0, &pressure(65535), 1);
+        let _ = reducer.reduce(1.0, &frame(), 1);
+
+        // Release the tip and leave proximity; both reset pressure to released.
+        let _ = reducer.reduce(1.0, &Event::Up, 2);
+        let _ = reducer.reduce(1.0, &frame(), 2);
+        let _ = reducer.reduce(1.0, &Event::ProximityOut, 3);
+        let _ = reducer.reduce(1.0, &frame(), 3);
+
+        // A new contact whose down frame carries no pressure must still report
+        // the active-unknown fallback, never the stale 0.0 from the last contact.
+        reducer.proximity_in(4);
+        let _ = reducer.reduce(1.0, &down(), 4);
+        let events = reducer.reduce(1.0, &frame(), 4);
+        let down = events
+            .iter()
+            .find_map(|e| match e {
+                PointerEvent::Down(d) => Some(d),
+                _ => None,
+            })
+            .expect("expected a tip down");
+        assert_eq!(down.state.pressure, ACTIVE_PRESSURE);
+    }
+
+    #[test]
+    fn second_tip_down_in_one_proximity_without_pressure_falls_back_to_active() {
+        let mut reducer = TabletToolReducer::default();
+        reducer.proximity_in(1);
+
+        // First tap reports real pressure, then the tip lifts.
+        let _ = reducer.reduce(1.0, &down(), 1);
+        let _ = reducer.reduce(1.0, &pressure(65535), 1);
+        let _ = reducer.reduce(1.0, &frame(), 1);
+        let _ = reducer.reduce(1.0, &Event::Up, 2);
+        let _ = reducer.reduce(1.0, &frame(), 2);
+
+        // A second tap in the same proximity, with no fresh pressure this frame,
+        // must not carry the released pressure from the first tap.
+        let _ = reducer.reduce(1.0, &down(), 3);
+        let events = reducer.reduce(1.0, &frame(), 3);
+        let down = events
+            .iter()
+            .find_map(|e| match e {
+                PointerEvent::Down(d) => Some(d),
+                _ => None,
+            })
+            .expect("expected a tip down");
+        assert_eq!(down.state.pressure, ACTIVE_PRESSURE);
     }
 
     #[test]

--- a/ui-events-wayland/src/tablet.rs
+++ b/ui-events-wayland/src/tablet.rs
@@ -60,6 +60,8 @@
 //! [`PointerButton::PenEraser`]: ui_events::pointer::PointerButton::PenEraser
 //! [`ui-events`]: https://docs.rs/ui-events/
 
+use alloc::vec::Vec;
+
 use ui_events::pointer::{
     PointerButton, PointerButtonEvent, PointerEvent, PointerInfo, PointerState, PointerType,
     PointerUpdate,

--- a/ui-events-wayland/src/touch.rs
+++ b/ui-events-wayland/src/touch.rs
@@ -1,0 +1,482 @@
+// Copyright 2026 the UI Events Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Reduces `wl_touch` event streams into [`PointerEvent`]s.
+//!
+//! [`TouchEventReducer`] mirrors the stateful-reducer pattern of the other
+//! adapters: feed it each `wl_touch` event for a seat's touch device together
+//! with a caller-provided monotonic timestamp, and it tracks every active
+//! contact and emits touch [`PointerEvent`]s.
+//!
+//! Wayland batches the touch changes that logically belong together — for
+//! example two fingers moving at once, or a contact's position alongside its
+//! updated shape — between `frame` events, and the order of `motion`, `shape`,
+//! and `orientation` within a frame is unspecified. The reducer therefore
+//! records each contact's new state as the events arrive and emits the resulting
+//! [`PointerEvent`]s only on `frame`, so a contact's geometry and orientation
+//! are fully assembled before its event is produced. Every emitted event carries
+//! `pointer_type` [`PointerType::Touch`] and no [`PointerButton`].
+//!
+//! Contacts are identified by their `wl_touch` contact id. The lowest active id
+//! is mapped to [`PointerId::PRIMARY`] and the rest are offset to avoid colliding
+//! with it; see [`mapping::touch_pointer_info`].
+//!
+//! [`PointerState`]: ui_events::pointer::PointerState
+//! [`PointerButton`]: ui_events::pointer::PointerButton
+//! [`PointerType::Touch`]: ui_events::pointer::PointerType::Touch
+//! [`PointerId::PRIMARY`]: ui_events::pointer::PointerId::PRIMARY
+
+use ui_events::pointer::{
+    PointerButtonEvent, PointerEvent, PointerInfo, PointerState, PointerUpdate,
+};
+use wayland_client::protocol::wl_touch::Event;
+
+use crate::mapping;
+use crate::pointer::TapCounter;
+
+/// Pressure reported while a touch contact is active.
+///
+/// `wl_touch` does not report pressure, so contacts follow the `ui-events`
+/// convention of `0.5` while down and `0.0` once released.
+const ACTIVE_PRESSURE: f32 = 0.5;
+/// Pressure reported once a touch contact is released or cancelled.
+const RELEASED_PRESSURE: f32 = 0.0;
+
+/// The latest change recorded for a contact within the current `frame`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Phase {
+    /// The contact was established (`wl_touch::down`).
+    Down,
+    /// The contact moved (`wl_touch::motion`).
+    Motion,
+    /// The contact was released (`wl_touch::up`).
+    Up,
+}
+
+/// A pending per-contact change to flush on the next `frame`.
+#[derive(Debug)]
+struct PendingChange {
+    /// The `wl_touch` contact id.
+    id: i32,
+    /// The latest phase seen for this contact in the current frame.
+    phase: Phase,
+}
+
+/// An active touch contact and its accumulated state.
+#[derive(Debug)]
+struct TouchContact {
+    /// The `wl_touch` contact id, unique among active contacts.
+    id: i32,
+    /// State accumulated from `down`, `motion`, `shape`, and `orientation`.
+    state: PointerState,
+}
+
+/// Reduces a `wl_touch` event stream into [`PointerEvent`]s.
+///
+/// Keep one reducer per seat touch device and call [`reduce`] with each
+/// `wl_touch` event. See the [module documentation] for the batching, identity,
+/// and timing model.
+///
+/// [`reduce`]: TouchEventReducer::reduce
+/// [module documentation]: self
+#[derive(Debug, Default)]
+pub struct TouchEventReducer {
+    /// Active contacts, keyed by `wl_touch` contact id.
+    contacts: Vec<TouchContact>,
+    /// Per-contact changes accumulated since the last `frame`.
+    pending: Vec<PendingChange>,
+    /// Multi-tap counter, shared with the pointer reducer.
+    counter: TapCounter,
+    /// Last caller-provided timestamp, for the monotonicity debug assertion.
+    last_seen_time: Option<u64>,
+}
+
+impl TouchEventReducer {
+    /// Reduce a single `wl_touch` [`Event`] into zero or more [`PointerEvent`]s.
+    ///
+    /// `time` is a monotonic nanosecond timestamp in the consumer's clock
+    /// domain, stamped into the [`PointerState`] of every contact this call
+    /// updates; Wayland's own 32-bit millisecond event timestamps are
+    /// deliberately not used as the clock. `scale_factor` converts surface-local
+    /// logical coordinates and contact dimensions to physical pixels.
+    ///
+    /// Down, motion, up, shape, and orientation events update the affected
+    /// contact but emit nothing; the accumulated [`PointerEvent`]s are returned
+    /// from the `frame` event that closes the batch. A `cancel` event returns a
+    /// [`PointerEvent::Cancel`] for every active contact immediately.
+    ///
+    /// `time` must be monotonic across calls; a regression trips a
+    /// `debug_assert!`, since tap detection measures durations in nanoseconds.
+    pub fn reduce(&mut self, scale_factor: f64, event: &Event, time: u64) -> Vec<PointerEvent> {
+        self.check_time_monotonic(time);
+
+        match event {
+            // `down` carries a `wl_surface` that cannot be constructed without a
+            // live connection, so the surface-independent logic lives in `down`.
+            Event::Down { id, x, y, .. } => {
+                self.down(*id, *x, *y, time, scale_factor);
+                Vec::new()
+            }
+            Event::Motion { id, x, y, .. } => {
+                self.motion(*id, *x, *y, time, scale_factor);
+                Vec::new()
+            }
+            Event::Up { id, .. } => {
+                self.up(*id, time, scale_factor);
+                Vec::new()
+            }
+            Event::Shape { id, major, minor } => {
+                self.shape(*id, *major, *minor, scale_factor);
+                Vec::new()
+            }
+            Event::Orientation { id, orientation } => {
+                self.orientation(*id, *orientation);
+                Vec::new()
+            }
+            Event::Frame => self.flush(scale_factor),
+            Event::Cancel => self.cancel(scale_factor),
+            // `wl_touch::Event` is `#[non_exhaustive]`; ignore future additions.
+            _ => Vec::new(),
+        }
+    }
+
+    /// Handle a `down` event: (re)establish a contact at the given surface-local
+    /// logical coordinates and record it for the next `frame`.
+    ///
+    /// This takes the coordinates rather than the `wl_touch::down` event, whose
+    /// `wl_surface` cannot be constructed without a live connection, so the
+    /// surface-independent logic stays unit-testable.
+    fn down(&mut self, id: i32, surface_x: f64, surface_y: f64, time: u64, scale_factor: f64) {
+        let state = PointerState {
+            time,
+            position: mapping::physical_position_from_logical(surface_x, surface_y, scale_factor),
+            pressure: ACTIVE_PRESSURE,
+            scale_factor,
+            ..PointerState::default()
+        };
+        if let Some(index) = self.contacts.iter().position(|c| c.id == id) {
+            self.contacts[index].state = state;
+        } else {
+            self.contacts.push(TouchContact { id, state });
+        }
+        self.mark_pending(id, Phase::Down);
+    }
+
+    /// Handle a `motion` event: update an existing contact's position.
+    fn motion(&mut self, id: i32, surface_x: f64, surface_y: f64, time: u64, scale_factor: f64) {
+        let Some(index) = self.contacts.iter().position(|c| c.id == id) else {
+            return;
+        };
+        let state = &mut self.contacts[index].state;
+        state.time = time;
+        state.scale_factor = scale_factor;
+        state.position =
+            mapping::physical_position_from_logical(surface_x, surface_y, scale_factor);
+        state.pressure = ACTIVE_PRESSURE;
+        self.mark_pending(id, Phase::Motion);
+    }
+
+    /// Handle an `up` event: mark an existing contact released.
+    fn up(&mut self, id: i32, time: u64, scale_factor: f64) {
+        let Some(index) = self.contacts.iter().position(|c| c.id == id) else {
+            return;
+        };
+        let state = &mut self.contacts[index].state;
+        state.time = time;
+        state.scale_factor = scale_factor;
+        state.pressure = RELEASED_PRESSURE;
+        self.mark_pending(id, Phase::Up);
+    }
+
+    /// Handle a `shape` event: update a contact's [`ContactGeometry`].
+    ///
+    /// [`ContactGeometry`]: ui_events::pointer::ContactGeometry
+    fn shape(&mut self, id: i32, major: f64, minor: f64, scale_factor: f64) {
+        if let Some(index) = self.contacts.iter().position(|c| c.id == id) {
+            self.contacts[index].state.contact_geometry =
+                mapping::contact_geometry_from_shape(major, minor, scale_factor);
+        }
+    }
+
+    /// Handle an `orientation` event: update a contact's orientation.
+    fn orientation(&mut self, id: i32, orientation_deg: f64) {
+        if let Some(index) = self.contacts.iter().position(|c| c.id == id) {
+            self.contacts[index].state.orientation =
+                mapping::touch_orientation_from_degrees(orientation_deg);
+        }
+    }
+
+    /// Emit the changes accumulated since the last `frame`, then drop any
+    /// contacts that were released.
+    fn flush(&mut self, scale_factor: f64) -> Vec<PointerEvent> {
+        if self.pending.is_empty() {
+            return Vec::new();
+        }
+        let Some(primary_id) = self.contacts.iter().map(|c| c.id).min() else {
+            self.pending.clear();
+            return Vec::new();
+        };
+        let pending = core::mem::take(&mut self.pending);
+
+        let mut events = Vec::with_capacity(pending.len());
+        for change in &pending {
+            let Some(contact) = self.contacts.iter().find(|c| c.id == change.id) else {
+                continue;
+            };
+            let state = contact.state.clone();
+            let pointer = mapping::touch_pointer_info(change.id as u64, primary_id as u64);
+            let event = match change.phase {
+                Phase::Down => PointerEvent::Down(PointerButtonEvent {
+                    button: None,
+                    pointer,
+                    state,
+                }),
+                Phase::Motion => PointerEvent::Move(PointerUpdate {
+                    pointer,
+                    current: state,
+                    coalesced: Vec::new(),
+                    predicted: Vec::new(),
+                }),
+                Phase::Up => PointerEvent::Up(PointerButtonEvent {
+                    button: None,
+                    pointer,
+                    state,
+                }),
+            };
+            events.push(self.counter.attach_count(scale_factor, event));
+        }
+
+        // Drop contacts that were released in this frame.
+        self.contacts
+            .retain(|c| !pending.iter().any(|p| p.id == c.id && p.phase == Phase::Up));
+
+        events
+    }
+
+    /// Handle a `cancel` event: emit a [`PointerEvent::Cancel`] for every active
+    /// contact and forget all touch state.
+    fn cancel(&mut self, scale_factor: f64) -> Vec<PointerEvent> {
+        let pointers: Vec<PointerInfo> = match self.contacts.iter().map(|c| c.id).min() {
+            Some(primary_id) => self
+                .contacts
+                .iter()
+                .map(|c| mapping::touch_pointer_info(c.id as u64, primary_id as u64))
+                .collect(),
+            None => Vec::new(),
+        };
+        self.contacts.clear();
+        self.pending.clear();
+        pointers
+            .into_iter()
+            .map(|pointer| {
+                self.counter
+                    .attach_count(scale_factor, PointerEvent::Cancel(pointer))
+            })
+            .collect()
+    }
+
+    /// Record the latest [`Phase`] seen for a contact in the current frame.
+    fn mark_pending(&mut self, id: i32, phase: Phase) {
+        if let Some(index) = self.pending.iter().position(|p| p.id == id) {
+            self.pending[index].phase = phase;
+        } else {
+            self.pending.push(PendingChange { id, phase });
+        }
+    }
+
+    /// Debug-assert that caller timestamps do not regress.
+    fn check_time_monotonic(&mut self, time: u64) {
+        if let Some(previous) = self.last_seen_time {
+            debug_assert!(
+                time >= previous,
+                "TouchEventReducer::reduce timestamps must be monotonic nanoseconds"
+            );
+        }
+        self.last_seen_time = Some(time);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use dpi::{PhysicalPosition, PhysicalSize};
+    use ui_events::pointer::{PointerId, PointerType};
+
+    use super::*;
+
+    fn frame() -> Event {
+        Event::Frame
+    }
+
+    fn motion(id: i32, x: f64, y: f64) -> Event {
+        Event::Motion { time: 0, id, x, y }
+    }
+
+    fn up(id: i32) -> Event {
+        Event::Up {
+            serial: 0,
+            time: 0,
+            id,
+        }
+    }
+
+    #[test]
+    fn single_contact_down_is_primary_with_scaled_position_and_pressure() {
+        let mut reducer = TouchEventReducer::default();
+        reducer.down(4, 10.0, 20.0, 100, 2.0);
+        let events = reducer.reduce(2.0, &frame(), 100);
+
+        assert_eq!(events.len(), 1);
+        let PointerEvent::Down(down) = &events[0] else {
+            panic!("expected a touch down, got {:?}", events[0]);
+        };
+        assert!(down.pointer.is_primary_pointer());
+        assert_eq!(down.pointer.pointer_type, PointerType::Touch);
+        assert_eq!(down.button, None);
+        assert_eq!(down.state.time, 100);
+        assert_eq!(down.state.scale_factor, 2.0);
+        assert_eq!(down.state.position, PhysicalPosition { x: 20.0, y: 40.0 });
+        assert_eq!(down.state.pressure, ACTIVE_PRESSURE);
+        assert_eq!(down.state.count, 1);
+    }
+
+    #[test]
+    fn motion_updates_position_and_keeps_primary() {
+        let mut reducer = TouchEventReducer::default();
+        reducer.down(4, 0.0, 0.0, 1, 1.0);
+        let _ = reducer.reduce(1.0, &frame(), 1);
+
+        let _ = reducer.reduce(1.0, &motion(4, 30.0, 40.0), 2);
+        let events = reducer.reduce(1.0, &frame(), 2);
+
+        assert_eq!(events.len(), 1);
+        let PointerEvent::Move(update) = &events[0] else {
+            panic!("expected a touch move, got {:?}", events[0]);
+        };
+        assert!(update.pointer.is_primary_pointer());
+        assert_eq!(update.pointer.pointer_type, PointerType::Touch);
+        assert_eq!(
+            update.current.position,
+            PhysicalPosition { x: 30.0, y: 40.0 }
+        );
+    }
+
+    #[test]
+    fn up_releases_contact_with_zero_pressure_and_drops_it() {
+        let mut reducer = TouchEventReducer::default();
+        reducer.down(4, 0.0, 0.0, 1, 1.0);
+        let _ = reducer.reduce(1.0, &frame(), 1);
+
+        let _ = reducer.reduce(1.0, &up(4), 2);
+        let release = reducer.reduce(1.0, &frame(), 2);
+        assert_eq!(release.len(), 1);
+        let PointerEvent::Up(up) = &release[0] else {
+            panic!("expected a touch up, got {:?}", release[0]);
+        };
+        assert!(up.pointer.is_primary_pointer());
+        assert_eq!(up.state.pressure, RELEASED_PRESSURE);
+
+        // The contact was dropped, so a later, higher-id touch becomes primary
+        // (the lowest active id) rather than being offset behind a lingering id.
+        reducer.down(9, 0.0, 0.0, 3, 1.0);
+        let next = reducer.reduce(1.0, &frame(), 3);
+        assert!(next[0].is_primary_pointer());
+    }
+
+    #[test]
+    fn lowest_concurrent_contact_is_primary_others_are_offset() {
+        let mut reducer = TouchEventReducer::default();
+        // Recorded id 5 first, then the lower id 2.
+        reducer.down(5, 0.0, 0.0, 1, 1.0);
+        reducer.down(2, 0.0, 0.0, 1, 1.0);
+        let events = reducer.reduce(1.0, &frame(), 1);
+
+        assert_eq!(events.len(), 2);
+        let PointerEvent::Down(higher) = &events[0] else {
+            panic!("expected a touch down for id 5, got {:?}", events[0]);
+        };
+        let PointerEvent::Down(lower) = &events[1] else {
+            panic!("expected a touch down for id 2, got {:?}", events[1]);
+        };
+        // The lowest active id (2) is the primary pointer.
+        assert!(lower.pointer.is_primary_pointer());
+        // The higher id (5) is offset by `POINTER_ID_OFFSET` (2) to 7.
+        assert!(!higher.pointer.is_primary_pointer());
+        assert_eq!(higher.pointer.pointer_id, PointerId::new(7));
+    }
+
+    #[test]
+    fn shape_and_orientation_within_frame_populate_state() {
+        let mut reducer = TouchEventReducer::default();
+        reducer.down(0, 5.0, 5.0, 1, 1.0);
+        let _ = reducer.reduce(
+            1.0,
+            &Event::Shape {
+                id: 0,
+                major: 10.0,
+                minor: 4.0,
+            },
+            1,
+        );
+        let _ = reducer.reduce(
+            1.0,
+            &Event::Orientation {
+                id: 0,
+                orientation: 0.0,
+            },
+            1,
+        );
+        let events = reducer.reduce(1.0, &frame(), 1);
+
+        let PointerEvent::Down(down) = &events[0] else {
+            panic!("expected a touch down, got {:?}", events[0]);
+        };
+        // Minor axis maps to width, major to height.
+        assert_eq!(
+            down.state.contact_geometry,
+            PhysicalSize {
+                width: 4.0,
+                height: 10.0
+            }
+        );
+        // A touch contact lies flat, so altitude stays perpendicular.
+        assert_eq!(
+            down.state.orientation.altitude,
+            core::f32::consts::FRAC_PI_2
+        );
+    }
+
+    #[test]
+    fn cancel_emits_for_all_contacts_and_clears_state() {
+        let mut reducer = TouchEventReducer::default();
+        reducer.down(0, 0.0, 0.0, 1, 1.0);
+        reducer.down(1, 0.0, 0.0, 1, 1.0);
+        let _ = reducer.reduce(1.0, &frame(), 1);
+
+        let cancelled = reducer.reduce(1.0, &Event::Cancel, 2);
+        assert_eq!(cancelled.len(), 2);
+        assert!(
+            cancelled
+                .iter()
+                .all(|e| matches!(e, PointerEvent::Cancel(_)))
+        );
+
+        // State was cleared, so a fresh, higher-id touch is the primary pointer.
+        reducer.down(9, 0.0, 0.0, 3, 1.0);
+        let next = reducer.reduce(1.0, &frame(), 3);
+        assert!(next[0].is_primary_pointer());
+    }
+
+    #[test]
+    fn frame_without_changes_emits_nothing() {
+        let mut reducer = TouchEventReducer::default();
+        assert!(reducer.reduce(1.0, &frame(), 1).is_empty());
+    }
+
+    #[test]
+    #[should_panic(expected = "timestamps must be monotonic nanoseconds")]
+    fn non_monotonic_time_panics_in_debug() {
+        let mut reducer = TouchEventReducer::default();
+        let _ = reducer.reduce(1.0, &frame(), 2_000);
+        let _ = reducer.reduce(1.0, &frame(), 1_000);
+    }
+}

--- a/ui-events-wayland/src/touch.rs
+++ b/ui-events-wayland/src/touch.rs
@@ -26,6 +26,7 @@
 //! [`PointerState`]: ui_events::pointer::PointerState
 //! [`PointerButton`]: ui_events::pointer::PointerButton
 //! [`PointerType::Touch`]: ui_events::pointer::PointerType::Touch
+//! [`PointerId`]: ui_events::pointer::PointerId
 //! [`PointerId::PRIMARY`]: ui_events::pointer::PointerId::PRIMARY
 
 use alloc::vec::Vec;

--- a/ui-events-wayland/src/touch.rs
+++ b/ui-events-wayland/src/touch.rs
@@ -26,6 +26,8 @@
 //! [`PointerType::Touch`]: ui_events::pointer::PointerType::Touch
 //! [`PointerId::PRIMARY`]: ui_events::pointer::PointerId::PRIMARY
 
+use alloc::vec::Vec;
+
 use ui_events::pointer::{
     PointerButtonEvent, PointerEvent, PointerInfo, PointerState, PointerUpdate,
 };

--- a/ui-events-wayland/src/touch.rs
+++ b/ui-events-wayland/src/touch.rs
@@ -17,9 +17,11 @@
 //! are fully assembled before its event is produced. Every emitted event carries
 //! `pointer_type` [`PointerType::Touch`] and no [`PointerButton`].
 //!
-//! Contacts are identified by their `wl_touch` contact id. The lowest active id
-//! is mapped to [`PointerId::PRIMARY`] and the rest are offset to avoid colliding
-//! with it; see [`mapping::touch_pointer_info`].
+//! Each contact is assigned a stable [`PointerId`] on the `frame` that first
+//! reports it and keeps that id until it lifts, so a contact joining later never
+//! changes an established contact's identity. While no contact holds it, the
+//! lowest active id claims [`PointerId::PRIMARY`]; the rest are offset to avoid
+//! colliding with it. See [`mapping::touch_pointer_info`].
 //!
 //! [`PointerState`]: ui_events::pointer::PointerState
 //! [`PointerButton`]: ui_events::pointer::PointerButton
@@ -71,6 +73,9 @@ struct TouchContact {
     id: i32,
     /// State accumulated from `down`, `motion`, `shape`, and `orientation`.
     state: PointerState,
+    /// The stable pointer identity, assigned on this contact's first `frame` and
+    /// retained until it lifts. `None` until that first `frame`.
+    pointer: Option<PointerInfo>,
 }
 
 /// Reduces a `wl_touch` event stream into [`PointerEvent`]s.
@@ -159,7 +164,11 @@ impl TouchEventReducer {
         if let Some(index) = self.contacts.iter().position(|c| c.id == id) {
             self.contacts[index].state = state;
         } else {
-            self.contacts.push(TouchContact { id, state });
+            self.contacts.push(TouchContact {
+                id,
+                state,
+                pointer: None,
+            });
         }
         self.mark_pending(id, Phase::Down);
     }
@@ -214,10 +223,7 @@ impl TouchEventReducer {
         if self.pending.is_empty() {
             return Vec::new();
         }
-        let Some(primary_id) = self.contacts.iter().map(|c| c.id).min() else {
-            self.pending.clear();
-            return Vec::new();
-        };
+        self.assign_pointer_ids();
         let pending = core::mem::take(&mut self.pending);
 
         let mut events = Vec::with_capacity(pending.len());
@@ -226,7 +232,10 @@ impl TouchEventReducer {
                 continue;
             };
             let state = contact.state.clone();
-            let pointer = mapping::touch_pointer_info(change.id as u64, primary_id as u64);
+            // Assigned above; every active contact has a stable identity here.
+            let Some(pointer) = contact.pointer else {
+                continue;
+            };
             let event = match change.phase {
                 Phase::Down => PointerEvent::Down(PointerButtonEvent {
                     button: None,
@@ -258,14 +267,8 @@ impl TouchEventReducer {
     /// Handle a `cancel` event: emit a [`PointerEvent::Cancel`] for every active
     /// contact and forget all touch state.
     fn cancel(&mut self, scale_factor: f64) -> Vec<PointerEvent> {
-        let pointers: Vec<PointerInfo> = match self.contacts.iter().map(|c| c.id).min() {
-            Some(primary_id) => self
-                .contacts
-                .iter()
-                .map(|c| mapping::touch_pointer_info(c.id as u64, primary_id as u64))
-                .collect(),
-            None => Vec::new(),
-        };
+        self.assign_pointer_ids();
+        let pointers: Vec<PointerInfo> = self.contacts.iter().filter_map(|c| c.pointer).collect();
         self.contacts.clear();
         self.pending.clear();
         pointers
@@ -275,6 +278,43 @@ impl TouchEventReducer {
                     .attach_count(scale_factor, PointerEvent::Cancel(pointer))
             })
             .collect()
+    }
+
+    /// Assign a stable [`PointerInfo`] to every contact that lacks one.
+    ///
+    /// A contact keeps the id assigned here until it lifts, so a contact joining
+    /// later never changes an established contact's identity. The primary slot is
+    /// claimed by the lowest-id contact still lacking an id, but only while no
+    /// active contact already holds it; once a contact owns the primary pointer it
+    /// keeps it until it lifts, and a surviving contact is never promoted.
+    fn assign_pointer_ids(&mut self) {
+        let primary_id = self
+            .contacts
+            .iter()
+            .find(|c| {
+                c.pointer
+                    .as_ref()
+                    .is_some_and(PointerInfo::is_primary_pointer)
+            })
+            .map(|c| c.id)
+            .or_else(|| {
+                self.contacts
+                    .iter()
+                    .filter(|c| c.pointer.is_none())
+                    .map(|c| c.id)
+                    .min()
+            });
+        let Some(primary_id) = primary_id else {
+            return;
+        };
+        for contact in &mut self.contacts {
+            if contact.pointer.is_none() {
+                contact.pointer = Some(mapping::touch_pointer_info(
+                    contact.id as u64,
+                    primary_id as u64,
+                ));
+            }
+        }
     }
 
     /// Record the latest [`Phase`] seen for a contact in the current frame.
@@ -404,6 +444,64 @@ mod tests {
         // The higher id (5) is offset by `POINTER_ID_OFFSET` (2) to 7.
         assert!(!higher.pointer.is_primary_pointer());
         assert_eq!(higher.pointer.pointer_id, PointerId::new(7));
+    }
+
+    #[test]
+    fn contact_keeps_its_pointer_id_when_a_lower_id_joins_later() {
+        let mut reducer = TouchEventReducer::default();
+        // Contact 5 is alone on its first frame, so it owns the primary pointer.
+        reducer.down(5, 0.0, 0.0, 1, 1.0);
+        let first = reducer.reduce(1.0, &frame(), 1);
+        let PointerEvent::Down(down5) = &first[0] else {
+            panic!("expected a touch down for id 5, got {:?}", first[0]);
+        };
+        assert!(down5.pointer.is_primary_pointer());
+        let id5 = down5.pointer.pointer_id;
+
+        // A lower id joins in a later frame. It must take a fresh, non-primary id
+        // rather than seizing the primary slot from the established contact 5.
+        reducer.down(2, 0.0, 0.0, 2, 1.0);
+        let second = reducer.reduce(1.0, &frame(), 2);
+        let PointerEvent::Down(down2) = &second[0] else {
+            panic!("expected a touch down for id 2, got {:?}", second[0]);
+        };
+        assert!(!down2.pointer.is_primary_pointer());
+
+        // Contact 5 moves: its pointer id is unchanged from its `down`.
+        let _ = reducer.reduce(1.0, &motion(5, 1.0, 1.0), 3);
+        let third = reducer.reduce(1.0, &frame(), 3);
+        let PointerEvent::Move(move5) = &third[0] else {
+            panic!("expected a touch move for id 5, got {:?}", third[0]);
+        };
+        assert!(move5.pointer.is_primary_pointer());
+        assert_eq!(move5.pointer.pointer_id, id5);
+    }
+
+    #[test]
+    fn primary_contact_lifting_does_not_promote_a_survivor() {
+        let mut reducer = TouchEventReducer::default();
+        reducer.down(5, 0.0, 0.0, 1, 1.0);
+        let _ = reducer.reduce(1.0, &frame(), 1);
+        reducer.down(2, 0.0, 0.0, 2, 1.0);
+        let second = reducer.reduce(1.0, &frame(), 2);
+        let PointerEvent::Down(down2) = &second[0] else {
+            panic!("expected a touch down for id 2, got {:?}", second[0]);
+        };
+        let id2 = down2.pointer.pointer_id;
+        assert!(!down2.pointer.is_primary_pointer());
+
+        // The primary contact lifts. The survivor keeps its own non-primary id
+        // rather than being promoted, which would change its identity mid-contact.
+        let _ = reducer.reduce(1.0, &up(5), 3);
+        let _ = reducer.reduce(1.0, &frame(), 3);
+
+        let _ = reducer.reduce(1.0, &motion(2, 1.0, 1.0), 4);
+        let fourth = reducer.reduce(1.0, &frame(), 4);
+        let PointerEvent::Move(move2) = &fourth[0] else {
+            panic!("expected a touch move for id 2, got {:?}", fourth[0]);
+        };
+        assert!(!move2.pointer.is_primary_pointer());
+        assert_eq!(move2.pointer.pointer_id, id2);
     }
 
     #[test]


### PR DESCRIPTION
Add `ui-events-wayland`, an adapter crate that bridges Wayland input into the `ui-events` model, mirroring the existing winit, web, and Apple adapters.

The crate is split in two. `mapping` holds platform-neutral, value-based conversions from Wayland input primitives — evdev button and key codes, surface-local coordinates, scroll axes, and modifier and capability bits — into `ui-events` building blocks; it performs no foreign-function calls, references no `wayland-client` types, and is unit-tested on every target. The stateful reducers that consume `wayland-client` and `wayland-protocols` event streams build on those helpers and are gated to `cfg(target_os = "linux")`, so on every other target the crate compiles to an essentially empty library that pulls in no platform dependencies. It is `no_std` and uses `alloc`; only the `xkb` feature pulls in `std`. It contains no `unsafe` and is `publish = false` for now.

The reducers cover a seat's input devices: `wl_pointer` (motion, buttons, and frame-batched scroll), `wl_touch` (multi-touch with per-contact geometry and orientation), `zwp_pointer_gestures_v1` touchpad pinch and rotate, `zwp_tablet_tool_v2` stylus input, and `wl_keyboard`. A `SeatReducer` aggregates the pointer, keyboard, and touch reducers behind a single `wl_seat`, tracking its advertised capabilities. Following the recent winit change, every reducer is host-clocked — the caller supplies a monotonic nanosecond timestamp and the surface scale factor — so Wayland input shares one clock and coordinate domain with frame sampling and the rest of the host.

The keyboard reducer resolves the physical W3C key code of every key with no system dependencies. An optional, non-default `xkb` feature additionally links `libxkbcommon` and uses the compositor's keymap to resolve logical key values, typed text, the key location, and the authoritative modifier set, including the lock states and the Alt Graph modifier. The keymap is compiled through xkbcommon's safe API, so the crate stays free of `unsafe`. Because `xkbcommon` links a system library and declares no MSRV, the feature is isolated: it is target-gated to Linux and inert elsewhere, and only the commit that adds it touches CI — installing `libxkbcommon` on the Linux test job and excluding the feature from the Miri and MSRV jobs.

The work is split into self-contained commits — the crate skeleton and neutral mapping, then one reducer per protocol, the `xkb` feature, and finally the seat aggregator — each of which builds and tests green on its own.
