### PR TITLE
ci: Pin cargo-rdme 1.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,11 @@ jobs:
       - name: check copyright headers
         run: bash .github/copyright.sh
 
+      # Pin to 1.5.1 due to issues with 2.x and intralinks / nightly builds.
       - name: install cargo-rdme
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-rdme
+          tool: cargo-rdme@1.5.1
 
       - name: cargo rdme (ui-events)
         # Ideally, we'd set heading-base-level=0 in the config file for cargo rdme, but that only


### PR DESCRIPTION
2.x brings pain with being tied to a specific version of rustdoc which requires pinning a particular nightly.