### PR TITLE
uikit: add pan recognizer scroll helper

### DIFF
--- a/ui-events-uikit/Cargo.toml
+++ b/ui-events-uikit/Cargo.toml
@@ -21,6 +21,7 @@ libm = ["dep:libm"]
 std = ["ui-events/std", "ui-events-apple-common/std", "dpi/std"]
 gestures = [
     "objc2-ui-kit/UIGestureRecognizer",
+    "objc2-ui-kit/UIPanGestureRecognizer",
     "objc2-ui-kit/UIPinchGestureRecognizer",
     "objc2-ui-kit/UIRotationGestureRecognizer",
 ]

--- a/ui-events-uikit/README.md
+++ b/ui-events-uikit/README.md
@@ -69,20 +69,22 @@ Currently supported:
 - Pencil hover maps to enter/move/leave when UIKit reports `RegionEntered`,
   `RegionMoved`, and `RegionExited`.
 - Finger touches use `button: None`, matching the DOM `TouchEvent` path in
-  `ui-events-web`. Active stylus contacts use [`PointerButton::Primary`](ui_events::pointer::PointerButton::Primary).
+  `ui-events-web`. Active stylus contacts use `PointerButton::Primary`.
 - UIKit exposes stylus `rollAngle`, but `ui-events` currently has no roll field.
 - UIKit exposes estimated-property update APIs, but `ui-events` currently has no sample-revision
   metadata for correcting previously emitted stylus samples.
 - UIKit does not expose a tangential-pressure value on `UITouch`, so
-  [`PointerState::tangential_pressure`](ui_events::pointer::PointerState::tangential_pressure)
-  remains `0.0` for this adapter.
+  `PointerState::tangential_pressure` remains `0.0` for this adapter.
 
 ## Gestures
 
-- Pinch gesture recognizers map to [`PointerGesture::Pinch`](ui_events::pointer::PointerGesture::Pinch)
+- Pinch gesture recognizers map to `PointerGesture::Pinch`
   by differencing UIKit's cumulative `scale` against a caller-provided
   previous scale. Rotation gesture recognizers follow the same pattern with
   cumulative counterclockwise `rotation` values.
+- Two-finger pan gesture recognizers can map to
+  `PointerEvent::Scroll` by differencing UIKit's cumulative translation
+  against a caller-provided previous translation.
 
 ## Text Notes
 
@@ -101,8 +103,10 @@ Currently supported:
 - `text::composition_update_event_with_utf16_ranges`
 - `pointer_event_from_touch_and_event`
 - `pointer_event_from_touch` (uncommon convenience helper)
+- `pointer_scroll_from_uipan` (feature: `gestures`)
 - `pointer_gesture_from_uipinch` (feature: `gestures`)
 - `pointer_gesture_from_uirotation` (feature: `gestures`)
+- `mapping::pan_scroll_delta_from_cumulative_translation` (feature: `gestures`)
 - `mapping::pinch_delta_from_cumulative_scale` (feature: `gestures`)
 - `mapping::rotation_delta_from_cumulative_rotation` (feature: `gestures`)
 

--- a/ui-events-uikit/src/lib.rs
+++ b/ui-events-uikit/src/lib.rs
@@ -47,20 +47,22 @@
 //! - Pencil hover maps to enter/move/leave when UIKit reports `RegionEntered`,
 //!   `RegionMoved`, and `RegionExited`.
 //! - Finger touches use `button: None`, matching the DOM `TouchEvent` path in
-//!   `ui-events-web`. Active stylus contacts use [`PointerButton::Primary`](ui_events::pointer::PointerButton::Primary).
+//!   `ui-events-web`. Active stylus contacts use `PointerButton::Primary`.
 //! - UIKit exposes stylus `rollAngle`, but `ui-events` currently has no roll field.
 //! - UIKit exposes estimated-property update APIs, but `ui-events` currently has no sample-revision
 //!   metadata for correcting previously emitted stylus samples.
 //! - UIKit does not expose a tangential-pressure value on `UITouch`, so
-//!   [`PointerState::tangential_pressure`](ui_events::pointer::PointerState::tangential_pressure)
-//!   remains `0.0` for this adapter.
+//!   `PointerState::tangential_pressure` remains `0.0` for this adapter.
 //!
 //! ## Gestures
 //!
-//! - Pinch gesture recognizers map to [`PointerGesture::Pinch`](ui_events::pointer::PointerGesture::Pinch)
+//! - Pinch gesture recognizers map to `PointerGesture::Pinch`
 //!   by differencing UIKit's cumulative `scale` against a caller-provided
 //!   previous scale. Rotation gesture recognizers follow the same pattern with
 //!   cumulative counterclockwise `rotation` values.
+//! - Two-finger pan gesture recognizers can map to
+//!   `PointerEvent::Scroll` by differencing UIKit's cumulative translation
+//!   against a caller-provided previous translation.
 //!
 //! ## Text Notes
 //!
@@ -79,8 +81,10 @@
 //! - `text::composition_update_event_with_utf16_ranges`
 //! - `pointer_event_from_touch_and_event`
 //! - `pointer_event_from_touch` (uncommon convenience helper)
+//! - `pointer_scroll_from_uipan` (feature: `gestures`)
 //! - `pointer_gesture_from_uipinch` (feature: `gestures`)
 //! - `pointer_gesture_from_uirotation` (feature: `gestures`)
+//! - `mapping::pan_scroll_delta_from_cumulative_translation` (feature: `gestures`)
 //! - `mapping::pinch_delta_from_cumulative_scale` (feature: `gestures`)
 //! - `mapping::rotation_delta_from_cumulative_rotation` (feature: `gestures`)
 //!
@@ -112,4 +116,6 @@ pub use uikit::{keyboard_event_from_uikey, keyboard_event_from_uipress};
 #[cfg(any(target_os = "ios", target_os = "tvos"))]
 pub use uikit::{pointer_event_from_touch, pointer_event_from_touch_and_event};
 #[cfg(all(any(target_os = "ios", target_os = "tvos"), feature = "gestures"))]
-pub use uikit::{pointer_gesture_from_uipinch, pointer_gesture_from_uirotation};
+pub use uikit::{
+    pointer_gesture_from_uipinch, pointer_gesture_from_uirotation, pointer_scroll_from_uipan,
+};

--- a/ui-events-uikit/src/mapping.rs
+++ b/ui-events-uikit/src/mapping.rs
@@ -3,7 +3,7 @@
 
 //! UIKit-specific mapping helpers for building `ui-events` from raw values.
 
-use dpi::PhysicalSize;
+use dpi::{PhysicalPosition, PhysicalSize};
 use ui_events::keyboard::{Code, Location, Modifiers, NamedKey};
 use ui_events::pointer::{PointerButton, PointerInfo, PointerType};
 pub use ui_events_apple_common::{
@@ -409,6 +409,48 @@ pub fn rotation_delta_from_cumulative_rotation(
     Some((previous_rotation_ccw - current_rotation_ccw) as f32)
 }
 
+/// Convert two cumulative UIKit pan translations into a physical-pixel scroll
+/// delta.
+///
+/// UIKit reports `UIPanGestureRecognizer::translationInView` as a cumulative
+/// translation in points since the recognizer began. This helper differences
+/// the current translation against a caller-provided previous translation,
+/// scales the result into physical pixels, and preserves UIKit's delta sign.
+///
+/// Returns `None` when the resulting finite delta is zero on both axes.
+pub fn pan_scroll_delta_from_cumulative_translation(
+    previous_x_points: f64,
+    previous_y_points: f64,
+    current_x_points: f64,
+    current_y_points: f64,
+    scale_factor: f64,
+) -> Option<PhysicalPosition<f64>> {
+    let scale_factor = positive_finite_or(scale_factor, 1.0);
+    let delta_x = finite_or(current_x_points - previous_x_points, 0.0) * scale_factor;
+    let delta_y = finite_or(current_y_points - previous_y_points, 0.0) * scale_factor;
+    if delta_x == 0.0 && delta_y == 0.0 {
+        return None;
+    }
+    Some(PhysicalPosition {
+        x: delta_x,
+        y: delta_y,
+    })
+}
+
+#[inline]
+fn finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() { value } else { fallback }
+}
+
+#[inline]
+fn positive_finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() && value > 0.0 {
+        value
+    } else {
+        fallback
+    }
+}
+
 /// Derive a normalized touch/stylus pressure in the range 0..=1.
 ///
 /// - If `active` is false, returns 0.0.
@@ -631,6 +673,34 @@ mod tests {
         assert_eq!(
             rotation_delta_from_cumulative_rotation(0.0, f64::INFINITY),
             None
+        );
+    }
+
+    #[test]
+    fn pan_scroll_delta_from_cumulative_translation_scales_delta() {
+        assert_eq!(
+            pan_scroll_delta_from_cumulative_translation(10.0, 20.0, 7.0, 24.0, 2.0),
+            Some(PhysicalPosition { x: -6.0, y: 8.0 })
+        );
+    }
+
+    #[test]
+    fn pan_scroll_delta_from_cumulative_translation_ignores_zero_or_non_finite_delta() {
+        assert_eq!(
+            pan_scroll_delta_from_cumulative_translation(10.0, 20.0, 10.0, 20.0, 2.0),
+            None
+        );
+        assert_eq!(
+            pan_scroll_delta_from_cumulative_translation(10.0, 20.0, f64::NAN, f64::INFINITY, 2.0),
+            None
+        );
+    }
+
+    #[test]
+    fn pan_scroll_delta_from_cumulative_translation_sanitizes_scale_factor() {
+        assert_eq!(
+            pan_scroll_delta_from_cumulative_translation(10.0, 20.0, 11.0, 22.0, -1.0),
+            Some(PhysicalPosition { x: 1.0, y: 2.0 })
         );
     }
 

--- a/ui-events-uikit/src/uikit.rs
+++ b/ui-events-uikit/src/uikit.rs
@@ -7,20 +7,25 @@
 // cfg is handled at the module declaration in lib.rs
 
 use alloc::string::ToString;
+#[cfg(feature = "gestures")]
+use objc2_core_foundation::CGPoint;
 use objc2_foundation::NSArray;
 use objc2_ui_kit::{UIEvent, UITouch, UITouchPhase, UITouchType};
 #[cfg(feature = "gestures")]
 use objc2_ui_kit::{
-    UIGestureRecognizerState, UIPinchGestureRecognizer, UIRotationGestureRecognizer,
+    UIGestureRecognizerState, UIPanGestureRecognizer, UIPinchGestureRecognizer,
+    UIRotationGestureRecognizer,
 };
 use objc2_ui_kit::{UIKey, UIPress, UIPressPhase, UIPressType};
 
 use crate::mapping as map;
+#[cfg(feature = "gestures")]
+use ui_events::ScrollDelta;
 use ui_events::keyboard::Modifiers;
 use ui_events::keyboard::{Code, Key, KeyState, KeyboardEvent, Location, NamedKey};
 use ui_events::pointer::{PointerEvent, PointerState, PointerType};
 #[cfg(feature = "gestures")]
-use ui_events::pointer::{PointerGesture, PointerGestureEvent};
+use ui_events::pointer::{PointerGesture, PointerGestureEvent, PointerScrollEvent};
 use ui_events::pointer::{PointerInfo, PointerUpdate};
 
 fn pointer_type_from_touch(touch: &UITouch) -> PointerType {
@@ -366,6 +371,78 @@ pub fn pointer_gesture_from_uirotation(
         gesture: PointerGesture::Rotate(rotation_cw),
         state,
     }))
+}
+
+/// Convert a two-finger `UIPanGestureRecognizer` into a `PointerEvent::Scroll`.
+///
+/// This is a lightweight convenience helper intended to be called from a
+/// `UIPanGestureRecognizer` callback installed by the host view.
+///
+/// Notes:
+/// - Returns `None` unless the recognizer is in `Changed` or `Ended` state and
+///   the finite pan delta is non-zero.
+/// - `previous_translation` must come from the same coordinate space as this
+///   helper uses: either the `CGPoint` returned by the previous
+///   `pointer_scroll_from_uipan` call, or a value read from
+///   `gesture.translationInView(None)`. Do not mix it with a
+///   `translationInView(Some(view))` value. Hosts should reset their stored
+///   translation when the recognizer enters `Began`, `Cancelled`, or `Failed`.
+/// - UIKit reports pan translation as cumulative point movement since the
+///   recognizer began; this helper differences it against `previous_translation`
+///   and scales the result into physical pixels.
+/// - `time_ns` is written directly to [`PointerState::time`], so callers can
+///   keep recognizer-derived scroll events in their host clock domain.
+///
+/// The returned `CGPoint` is the current cumulative translation and should be
+/// retained by the host as the next `previous_translation`.
+#[cfg(feature = "gestures")]
+pub fn pointer_scroll_from_uipan(
+    gesture: &UIPanGestureRecognizer,
+    previous_translation: CGPoint,
+    scale_factor: f64,
+    time_ns: u64,
+) -> Option<(PointerEvent, CGPoint)> {
+    let gr_state: UIGestureRecognizerState = gesture.state();
+    if !(gr_state == UIGestureRecognizerState::Changed
+        || gr_state == UIGestureRecognizerState::Ended)
+    {
+        return None;
+    }
+    let translation = gesture.translationInView(None);
+    let delta = map::pan_scroll_delta_from_cumulative_translation(
+        previous_translation.x,
+        previous_translation.y,
+        translation.x,
+        translation.y,
+        scale_factor,
+    )?;
+    let loc = gesture.locationInView(None);
+    let mut state = map::pointer_state_from_raw(
+        loc.x,
+        loc.y,
+        scale_factor,
+        0,
+        false,
+        false,
+        false,
+        false,
+        None,
+        None,
+        None,
+        None,
+        0.0,
+        0,
+    );
+    state.time = time_ns;
+
+    Some((
+        PointerEvent::Scroll(PointerScrollEvent {
+            pointer: map::pointer_info_primary_for_type(PointerType::Touch),
+            delta: ScrollDelta::PixelDelta(delta),
+            state,
+        }),
+        translation,
+    ))
 }
 
 /// Convert a `UIPress` (tvOS/Apple TV remote) into a `KeyboardEvent`.


### PR DESCRIPTION
Add `pointer_scroll_from_uipan` so UIKit hosts can keep ownership of installing and retaining `UIPanGestureRecognizer` while `ui-events-uikit` owns translating recognizer state into `PointerEvent::Scroll`.

The helper differences cumulative `translationInView` values against a caller-provided previous `CGPoint`, scales point deltas into physical pixels, filters zero/non-finite deltas, and writes caller-provided `time_ns` directly into `PointerState::time` for host-clock integration.

Also expose the raw `mapping::pan_scroll_delta_from_cumulative_translation` helper with tests and document the new `gestures` surface in the generated README.