### PR TITLE
wayland: load the keymap with a size-bounded positional read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1226,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1384,7 @@ version = "0.3.0"
 dependencies = [
  "dpi",
  "libm",
+ "tempfile",
  "ui-events",
  "wayland-client",
  "wayland-protocols",

--- a/ui-events-wayland/Cargo.toml
+++ b/ui-events-wayland/Cargo.toml
@@ -37,5 +37,9 @@ wayland-client = "0.31"
 wayland-protocols = { version = "0.32", features = ["client", "unstable"] }
 xkbcommon = { version = "0.9", optional = true, default-features = false }
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+# Backs the `xkb` keymap-loading regression test with a real seekable fd.
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/ui-events-wayland/src/keyboard.rs
+++ b/ui-events-wayland/src/keyboard.rs
@@ -58,9 +58,13 @@
 //! [`NamedKey::Unidentified`]: ui_events::keyboard::NamedKey::Unidentified
 //! [`Location::Standard`]: ui_events::keyboard::Location::Standard
 
+#[cfg(feature = "xkb")]
+use alloc::string::String;
 use alloc::vec::Vec;
 #[cfg(feature = "xkb")]
 use std::fs::File;
+#[cfg(feature = "xkb")]
+use std::os::unix::fs::FileExt;
 #[cfg(feature = "xkb")]
 use std::os::unix::io::OwnedFd;
 
@@ -141,8 +145,8 @@ impl KeyboardEventReducer {
             // Under the `xkb` feature the keymap drives logical-key and
             // authoritative-modifier resolution.
             #[cfg(feature = "xkb")]
-            Event::Keymap { format, fd, .. } => {
-                self.xkb.set_keymap(*format, fd);
+            Event::Keymap { format, fd, size } => {
+                self.xkb.set_keymap(*format, fd, *size);
                 None
             }
             #[cfg(feature = "xkb")]
@@ -302,20 +306,37 @@ impl XkbState {
     /// keyboard state from it.
     ///
     /// Only the XKB v1 text format is understood; any other format is ignored,
-    /// as is a keymap that fails to compile (the previous state is kept). The
-    /// file descriptor is duplicated and read rather than memory-mapped, so the
-    /// reducer needs no `unsafe` and leaves the caller's descriptor undisturbed.
-    fn set_keymap(&mut self, format: WEnum<KeymapFormat>, fd: &OwnedFd) {
+    /// as is a keymap that fails to compile (the previous state is kept).
+    ///
+    /// The `keymap` descriptor is meant to be mapped, not streamed: the protocol
+    /// guarantees only that the keymap occupies its first `size` bytes, and the
+    /// descriptor arrives sharing the compositor's open file description, so its
+    /// seek position is wherever the compositor left it. Rather than `mmap`
+    /// (which would need `unsafe`), read exactly `size` bytes from offset `0`
+    /// with a positional read, which neither depends on nor disturbs that shared
+    /// seek position.
+    fn set_keymap(&mut self, format: WEnum<KeymapFormat>, fd: &OwnedFd, size: u32) {
         if !matches!(format, WEnum::Value(KeymapFormat::XkbV1)) {
             return;
         }
         let Ok(fd) = fd.try_clone() else {
             return;
         };
-        let mut file = File::from(fd);
-        if let Some(keymap) = xkb::Keymap::new_from_file(
+        let file = File::from(fd);
+        let mut keymap = alloc::vec![0_u8; size as usize];
+        if file.read_exact_at(&mut keymap, 0).is_err() {
+            return;
+        }
+        // The keymap is NUL-terminated on the wire; drop it for the string.
+        if keymap.last() == Some(&0) {
+            keymap.pop();
+        }
+        let Ok(keymap) = String::from_utf8(keymap) else {
+            return;
+        };
+        if let Some(keymap) = xkb::Keymap::new_from_string(
             &self.context,
-            &mut file,
+            keymap,
             xkb::KEYMAP_FORMAT_TEXT_V1,
             xkb::KEYMAP_COMPILE_NO_FLAGS,
         ) {
@@ -638,5 +659,54 @@ mod tests {
             group: 0,
         });
         assert!(reducer.modifiers().shift());
+    }
+
+    /// A compositor delivers the keymap on a descriptor whose seek position it
+    /// leaves at end-of-file; loading must not depend on that position.
+    /// Regression test for keyboard input going dead because the keymap read
+    /// nothing.
+    #[cfg(feature = "xkb")]
+    #[test]
+    fn xkb_loads_keymap_from_descriptor_parked_at_end_of_file() {
+        use std::io::{Seek, SeekFrom, Write};
+        use std::os::fd::OwnedFd;
+
+        let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
+        let Some(keymap) = xkb::Keymap::new_from_names(
+            &context,
+            "",
+            "",
+            "us",
+            "",
+            None,
+            xkb::KEYMAP_COMPILE_NO_FLAGS,
+        ) else {
+            return; // No XKB keymap data on this system; skip.
+        };
+        // Mirror the wire format: the keymap text followed by a NUL terminator.
+        let mut bytes = keymap
+            .get_as_string(xkb::KEYMAP_FORMAT_TEXT_V1)
+            .into_bytes();
+        bytes.push(0);
+        let size = u32::try_from(bytes.len()).expect("keymap size fits in u32");
+
+        let mut file = tempfile::tempfile().expect("create a temp keymap file");
+        file.write_all(&bytes).expect("write the keymap");
+        // The position a compositor leaves the descriptor at — the bug's trigger.
+        file.seek(SeekFrom::End(0)).expect("seek to end");
+        let fd = OwnedFd::from(file);
+
+        let mut reducer = KeyboardEventReducer::default();
+        reducer.reduce(&Event::Keymap {
+            format: WEnum::Value(KeymapFormat::XkbV1),
+            fd,
+            size,
+        });
+
+        // With the keymap loaded, the physical `A` key resolves its typed text.
+        let event = reducer
+            .reduce(&key_event(KEY_A, WlKeyState::Pressed))
+            .expect("a key press should translate");
+        assert_eq!(event.key, Key::Character("a".into()));
     }
 }


### PR DESCRIPTION
## Problem

The `wl_keyboard` `keymap` file descriptor arrives over the Wayland socket
sharing the compositor's open file description, so its seek position is wherever
the compositor left it — in practice end-of-file, right after it wrote the
keymap. The `xkb` path of `KeyboardEventReducer` loaded the keymap with
`xkbcommon::Keymap::new_from_file`, which streams from the descriptor's *current*
position, so it read **zero bytes**. The keymap then failed to compile
(`XKB-822: Failed to parse input xkb string`) and the reducer never built an
`xkb::State`: every key resolved to `Key::Named(NamedKey::Unidentified)`, no
typed text was produced, and the modifier set silently fell back to physical-key
tracking. In practice keyboard input was dead.

(The trailing NUL the protocol appends is not the cause — libxkbcommon strips a
single trailing NUL. It is purely the file offset.)

## Fix

Read exactly the protocol-provided `size` bytes from offset `0` with a positional
read (`read_exact_at`/`pread`) and compile from that. It:

- is independent of the descriptor's seek position, so it cannot read nothing;
- honors the `size` the protocol guarantees instead of streaming to EOF;
- does not disturb the shared seek position the borrowed descriptor points at.

This is the safe analog of the size-bounded `mmap`-from-0 that mapping-based
consumers (e.g. winit) use, without the `unsafe` this crate avoids by reading
rather than mapping.

## Test

Adds an `xkb`-gated regression test that writes a real keymap to a descriptor,
seeks it to end-of-file (the offset that tripped the bug), feeds the `Keymap`
event, and asserts a subsequent `KEY_A` press resolves to `Key::Character("a")`.
Backed by a `tempfile` dev-dependency for a seekable fd.

Verified against a live compositor: the received fd's offset equals `size`, a
read from the current position returns 0 bytes, and the positional read compiles
the keymap cleanly.